### PR TITLE
Bugfix: regex match and overflow display

### DIFF
--- a/site/src/demo/Demo.tsx
+++ b/site/src/demo/Demo.tsx
@@ -165,12 +165,7 @@ const PublicityPage = () => {
               </Col>
             </Row> */}
           </Layout>
-          {/* <Layout dir="vertical">
-            <Row gutter={[16, 16]}>
-              <Col span={24}>
-                <DemoPage />
-              </Col>
-            </Row>
+          <Layout dir="vertical">
             <Row gutter={[16, 16]}>
               <Col span={12}>
                 <Text style={{ fontSize: '20px', fontWeight: 'bold' }}>Input Article</Text>
@@ -190,7 +185,7 @@ const PublicityPage = () => {
                 <ArtcleProcess llmarticle={llmarticle} />
               </Col>
             </Row>
-          </Layout>*/}
+          </Layout>
         </Content> 
       </ConfigProvider>
     </div>

--- a/site/src/demo/demoPage.tsx
+++ b/site/src/demo/demoPage.tsx
@@ -6,6 +6,206 @@ import ArtcleProcess from '../modules/visualizer/renderer/renderer';
 const { Text } = Typography;
 
 export const DemoPage = () => {
+  const sampleArticle2: paragraphSpec[] = [
+    {
+      paragraphIdx: 0,
+      paragraphContent: [
+        {
+          id: 'p0s0',
+          unitSegmentSpec: {
+            insightType: 'noType',
+            segmentIdx: 0,
+            context: '2024 has been another year of fierce competition in the EV sector.',
+          },
+        },
+      ],
+    },
+    {
+      paragraphIdx: 1,
+      paragraphContent: [
+        {
+          id: 'p1s0',
+          unitSegmentSpec: {
+            insightType: 'trend',
+            segmentIdx: 0,
+            context:
+              'BYD had another record year with worldwide car production in 2024. In 2024 (January to December), BYD produced more than 4 million units, an increase of 41.3% year-on-year.',
+            inSituPosition: [],
+            attribute: 'positive',
+          },
+          dataSpec: [
+            {
+              categoryKey: 'the category of car production',
+              categoryValue: 'BYD',
+              valueKey: 'the number of cars produced',
+              valueValue: 4000000,
+            },
+            {
+              categoryKey: 'the category of car production growth rate',
+              categoryValue: 'BYD',
+              valueKey: 'the year-on-year growth rate of car production',
+              valueValue: 41.3,
+            },
+          ],
+        },
+        {
+          id: 'p1s1',
+          unitSegmentSpec: {
+            insightType: 'trend',
+            segmentIdx: 1,
+            context:
+              'BYD sales have steadily increased in the past five years (2019 - 2023). Specifically, BYD sales 409k, 395k, 721k, 1802k, and 3024k respectively.',
+            inSituPosition: [],
+            attribute: 'positive',
+          },
+          dataSpec: [
+            {
+              categoryKey: 'the category of BYD sales',
+              categoryValue: 'BYD sales',
+              valueKey: 'the number of BYD sales',
+              valueValue: 409000,
+            },
+            {
+              categoryKey: 'the category of BYD sales',
+              categoryValue: 'BYD sales',
+              valueKey: 'the number of BYD sales',
+              valueValue: 395000,
+            },
+            {
+              categoryKey: 'the category of BYD sales',
+              categoryValue: 'BYD sales',
+              valueKey: 'the number of BYD sales',
+              valueValue: 721000,
+            },
+            {
+              categoryKey: 'the category of BYD sales',
+              categoryValue: 'BYD sales',
+              valueKey: 'the number of BYD sales',
+              valueValue: 1802000,
+            },
+            {
+              categoryKey: 'the category of BYD sales',
+              categoryValue: 'BYD sales',
+              valueKey: 'the number of BYD sales',
+              valueValue: 3024000,
+            },
+          ],
+        },
+        {
+          id: 'p1s2',
+          unitSegmentSpec: {
+            insightType: 'extreme',
+            segmentIdx: 2,
+            context: 'The best-selling type, the BYD Song series, sold 636530 units on its own.',
+            inSituPosition: ['636530'],
+            attribute: 'maximum',
+          },
+          dataSpec: [
+            {
+              categoryKey: 'the category of vehicle sales',
+              categoryValue: 'BYD Song series',
+              valueKey: 'the number of units sold',
+              valueValue: 636530,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      paragraphIdx: 2,
+      paragraphContent: [
+        {
+          id: 'p2s0',
+          unitSegmentSpec: {
+            insightType: 'proportion',
+            segmentIdx: 0,
+            context:
+              'This sales figure made BYD the biggest EV manufacturer in terms of market share. Specifically, BYD constitutes 22% of global sales.',
+            inSituPosition: [],
+          },
+          dataSpec: [
+            {
+              categoryKey: 'the category of market share in global EV sales',
+              categoryValue: 'BYD',
+              valueKey: 'the proportion of global EV sales',
+              valueValue: 0.22,
+            },
+            {
+              categoryKey: 'the category of market share in global EV sales',
+              categoryValue: 'Other manufacturers',
+              valueKey: 'the proportion of global EV sales',
+              valueValue: 0.78,
+            },
+          ],
+        },
+        {
+          id: 'p2s1',
+          unitSegmentSpec: {
+            insightType: 'rank',
+            segmentIdx: 1,
+            context: 'Meanwhile, the top 5 sellers are BYD, Tesla, VW, Geely-Volvo Car Group, and SAIC.',
+            inSituPosition: [],
+          },
+          dataSpec: [
+            {
+              categoryKey: 'seller',
+              categoryValue: 'BYD',
+              valueKey: 'sales rank',
+              valueValue: 1,
+            },
+            {
+              categoryKey: 'seller',
+              categoryValue: 'Tesla',
+              valueKey: 'sales rank',
+              valueValue: 2,
+            },
+            {
+              categoryKey: 'seller',
+              categoryValue: 'VW',
+              valueKey: 'sales rank',
+              valueValue: 3,
+            },
+            {
+              categoryKey: 'seller',
+              categoryValue: 'Geely-Volvo Car Group',
+              valueKey: 'sales rank',
+              valueValue: 4,
+            },
+            {
+              categoryKey: 'seller',
+              categoryValue: 'SAIC',
+              valueKey: 'sales rank',
+              valueValue: 5,
+            },
+          ],
+        },
+        {
+          id: 'p2s2',
+          unitSegmentSpec: {
+            insightType: 'comparison',
+            segmentIdx: 2,
+            context: 'The difference in market share between Tesla and BYD is now 8.8%.',
+            inSituPosition: [],
+          },
+          dataSpec: [
+            {
+              categoryKey: 'the category of market share',
+              categoryValue: 'Tesla',
+              valueKey: 'the market share percentage',
+              valueValue: 0,
+            },
+            {
+              categoryKey: 'the category of market share',
+              categoryValue: 'BYD',
+              valueKey: 'the market share percentage',
+              valueValue: 8.8,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
   const sampleArticle: paragraphSpec[] = [
     {
       paragraphIdx: 1,
@@ -220,6 +420,7 @@ export const DemoPage = () => {
         <Divider style={{ margin: '0 0 0 0' }} />
         <div style={{ width: '50%', margin: '0 auto' }}>
           <ArtcleProcess llmarticle={sampleArticle} />
+          <ArtcleProcess llmarticle={sampleArticle2} />
         </div>
       </Layout>
     </div>

--- a/site/src/modules/visualizer/utils/fuzzySearch.ts
+++ b/site/src/modules/visualizer/utils/fuzzySearch.ts
@@ -6,13 +6,15 @@ export const fuzzySearch = (queryString: string, context: string, isFuzzy: boole
   // const queryString = "the rest of the top 5 companies";
   if (!isFuzzy) {
     // use direct match to find all matches, case insensitive
-    const regex = new RegExp(`\\b${queryString}\\b`, 'i');
-    const matches = context.match(regex);
-    if (matches) {
-      return matches.map((match) => [matches.index, matches.index ? matches.index + match.length : 0]);
-    }
-    return [];
+    const regex = new RegExp(`\\b${queryString}\\b`, 'gi');
+    const matches = Array.from(context.matchAll(regex), (match) => {
+      const startIndex = match.index;
+      const endIndex = startIndex + match[0].length;
+      return [startIndex, endIndex];
+    });
+    return matches;
   }
+
   const options = {
     shouldSort: true,
     includeMatches: true,

--- a/site/src/modules/visualizer/widgets/hoverText.tsx
+++ b/site/src/modules/visualizer/widgets/hoverText.tsx
@@ -5,7 +5,7 @@ const styles = {
     transition: 'color 0.3s, border 0.3s, transform 0.3s, box-shadow 0.3s, font-weight 0.3s',
     border: '2px solid transparent',
     borderRadius: '8px',
-    display: 'inline-block',
+    // display: 'inline-block',
   },
   hoveredText: {
     boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',


### PR DESCRIPTION
- Fix regex match failed to capture entity when it's the first word and erroneous implementation of multiple matches.
- Fix unintended setup that made highlight entity boxes as "inline-block," which created visually unpleasant big spaces.