### PR TITLE
Bugfix: regex match

### DIFF
--- a/site/src/modules/visualizer/utils/fuzzySearch.ts
+++ b/site/src/modules/visualizer/utils/fuzzySearch.ts
@@ -4,9 +4,21 @@ export const fuzzySearch = (queryString: string, context: string, isFuzzy: boole
   // const context =
   //   "The percentage of the sales of BYD is 30%, while the rest of the top 5 companies only consist of 25%. BYD";
   // const queryString = "the rest of the top 5 companies";
+
   if (!isFuzzy) {
     // use direct match to find all matches, case insensitive
-    const regex = new RegExp(`\\b${queryString}\\b`, 'gi');
+
+    // Escape special characters in a string to safely insert it into a regular expression
+    const escapeRegExp = (text: string) => {
+      return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    };
+
+    const escapedQuery = escapeRegExp(queryString);
+    // Determine if word boundaries should be applied based on the first and last character
+    const startBoundary = /^\w/.test(queryString) ? '\\b' : '';
+    const endBoundary = /\w$/.test(queryString) ? '\\b' : '';
+    const regex = new RegExp(`${startBoundary}${escapedQuery}${endBoundary}`, 'gi');
+
     const matches = Array.from(context.matchAll(regex), (match) => {
       const startIndex = match.index;
       const endIndex = startIndex + match[0].length;


### PR DESCRIPTION
### **Solution:**
- **Escaped Special Characters:**  
  A helper function `escapeRegExp` has been added to escape any special regex characters in the query string, ensuring that characters like `"."` are treated as literals.
  
- **Improved Word Boundary Handling:**  
  The word boundaries (`\b`) are now applied conditionally based on whether the first and last characters of the query string are word characters (letters, digits, or underscores). This ensures that word boundaries are only used when appropriate, avoiding issues with punctuation.

### **Changes:**
- Added `escapeRegExp` function to escape special regex characters.
- Updated the regular expression construction to dynamically apply word boundaries based on the query string's characters.

### **Impact:**
This change ensures that queries with punctuation (e.g., `"U.S."`) are correctly matched in the provided context, while maintaining the functionality for other queries. It improves the robustness of the `fuzzySearch` function in non-fuzzy mode. 