### PR TITLE
fix: TrendVisualizers display wrong colors

### DIFF
--- a/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
+++ b/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
@@ -48,7 +48,7 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
         : validForNominalTrend && !hasNaN && numEntries === 2
           ? 'start-end'
           : 'actual';
-          
+
   const transformData = (): DataPoint[] => {
     if (lineChartType === 'nominal' || lineChartType === 'trending') {
       return dummyDataMap[attribute];

--- a/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
+++ b/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
@@ -48,6 +48,7 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
         : validForNominalTrend && !hasNaN && numEntries === 2
           ? 'start-end'
           : 'actual';
+          
   const transformData = (): DataPoint[] => {
     if (lineChartType === 'nominal' || lineChartType === 'trending') {
       return dummyDataMap[attribute];

--- a/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
+++ b/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
@@ -24,17 +24,15 @@ const dummyDataMap: { [key in TrendAttribute]: DataPoint[] } = {
 };
 
 const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
-
   const id = gistvisSpec.id;
-  const trendId = gistvisSpec.unitSegmentSpec.attribute+id;
-  
+  const trendId = gistvisSpec.unitSegmentSpec.attribute + id;
+
   const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('trend-' + trendId);
   const [currentEntity, setCurrentEntity] = useState<string>('');
   const dataSpec = gistvisSpec.dataSpec ?? [];
   const attribute = (gistvisSpec.unitSegmentSpec.attribute as TrendAttribute) ?? '';
 
   const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
-  
   const uniqueEntities = getUniqueEntities(entityPos);
 
   const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos);
@@ -42,13 +40,8 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
   const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
 
   const hasNaN = dataSpec.some((d) => isNaN(d.valueValue));
-  // console.log('hasNaN',hasNaN);
   const numEntries = dataSpec.length;
-  // console.log('numEntries',numEntries);
-  
   const validForNominalTrend = attribute === 'negative' || attribute === 'positive';
-  // console.log('validForNominalTrend',validForNominalTrend);
-  
   const lineChartType: TrendOptions =
     validForNominalTrend && (hasNaN || numEntries === 0)
       ? 'nominal'
@@ -57,9 +50,6 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
         : validForNominalTrend && !hasNaN && numEntries === 2
           ? 'start-end'
           : 'actual';
-  // console.log('lineChartType',lineChartType);
-  
-
   const transformData = (): DataPoint[] => {
     if (lineChartType === 'nominal' || lineChartType === 'trending') {
       return dummyDataMap[attribute];

--- a/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
+++ b/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
@@ -25,9 +25,7 @@ const dummyDataMap: { [key in TrendAttribute]: DataPoint[] } = {
 
 const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
   const id = gistvisSpec.id;
-  const trendId = gistvisSpec.unitSegmentSpec.attribute + id;
-
-  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('trend-' + trendId);
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('trend-' + id);
   const [currentEntity, setCurrentEntity] = useState<string>('');
   const dataSpec = gistvisSpec.dataSpec ?? [];
   const attribute = (gistvisSpec.unitSegmentSpec.attribute as TrendAttribute) ?? '';

--- a/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
+++ b/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
@@ -24,13 +24,17 @@ const dummyDataMap: { [key in TrendAttribute]: DataPoint[] } = {
 };
 
 const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+
   const id = gistvisSpec.id;
-  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('trend-' + id);
+  const trendId = gistvisSpec.unitSegmentSpec.attribute+id;
+  
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('trend-' + trendId);
   const [currentEntity, setCurrentEntity] = useState<string>('');
   const dataSpec = gistvisSpec.dataSpec ?? [];
   const attribute = (gistvisSpec.unitSegmentSpec.attribute as TrendAttribute) ?? '';
 
   const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  
   const uniqueEntities = getUniqueEntities(entityPos);
 
   const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos);
@@ -38,8 +42,13 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
   const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
 
   const hasNaN = dataSpec.some((d) => isNaN(d.valueValue));
+  // console.log('hasNaN',hasNaN);
   const numEntries = dataSpec.length;
+  // console.log('numEntries',numEntries);
+  
   const validForNominalTrend = attribute === 'negative' || attribute === 'positive';
+  // console.log('validForNominalTrend',validForNominalTrend);
+  
   const lineChartType: TrendOptions =
     validForNominalTrend && (hasNaN || numEntries === 0)
       ? 'nominal'
@@ -48,6 +57,8 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
         : validForNominalTrend && !hasNaN && numEntries === 2
           ? 'start-end'
           : 'actual';
+  // console.log('lineChartType',lineChartType);
+  
 
   const transformData = (): DataPoint[] => {
     if (lineChartType === 'nominal' || lineChartType === 'trending') {

--- a/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
@@ -182,14 +182,14 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             fill="none"
             stroke={lineColor}
             strokeWidth={1}
-            markerStart={lineColor == 'green' ? 'url(#arrow-start-green)' : 'url(#arrow-start-red)'}
-            markerEnd={lineColor == 'green' ? 'url(#arrow-end-green)' : 'url(#arrow-end-red)'}
+            markerStart={`url(#arrow-start-${lineColor})`}
+            markerEnd={`url(#arrow-end-${lineColor})`}
           />
         )}
 
         <defs>
           <marker
-            id="arrow-end"
+            id={`arrow-end-${lineColor}`}
             markerWidth="4"
             markerHeight="4"
             refX="3"
@@ -203,7 +203,7 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
 
         <defs>
           <marker
-            id="arrow-start"
+            id={`arrow-start-${lineColor}`}
             markerWidth="4"
             markerHeight="4"
             refX="1"
@@ -212,60 +212,6 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             markerUnits="strokeWidth"
           >
             <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
-          </marker>
-        </defs>
-
-        <defs>
-          <marker
-            id="arrow-end-green"
-            markerWidth="4"
-            markerHeight="4"
-            refX="3"
-            refY="2"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M0,0 L0,4 L4,2 z" fill={'green'} />
-          </marker>
-        </defs>
-        <defs>
-          <marker
-            id="arrow-start-green"
-            markerWidth="4"
-            markerHeight="4"
-            refX="1"
-            refY="2"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M4,0 L4,4 L0,2 z" fill={'green'} />
-          </marker>
-        </defs>
-        <defs>
-          <marker
-            id="arrow-end-red"
-            markerWidth="4"
-            markerHeight="4"
-            refX="3"
-            refY="2"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M0,0 L0,4 L4,2 z" fill={'red'} />
-          </marker>
-        </defs>
-
-        <defs>
-          <marker
-            id="arrow-start-red"
-            markerWidth="4"
-            markerHeight="4"
-            refX="1"
-            refY="2"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M4,0 L4,4 L0,2 z" fill={'red'} />
           </marker>
         </defs>
 

--- a/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
@@ -152,9 +152,9 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
         ? 'green'
         : 'red'
       : colorScale(dataSpec[0].categoryValue);
-  console.log('lineColor', lineColor);
-  
-  const uid = gistvisSpec.unitSegmentSpec.insightType+'-'+gistvisSpec.unitSegmentSpec.attribute+'-'+gistvisSpec.id;
+
+  const uid =
+    gistvisSpec.unitSegmentSpec.insightType + '-' + gistvisSpec.unitSegmentSpec.attribute + '-' + gistvisSpec.id;
   return (
     <Tooltip title={tooltip != null ? getTooltipContnet(tooltip.value) : ''} placement="bottom" color="#ffffff">
       <svg
@@ -182,8 +182,8 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             fill="none"
             stroke={lineColor}
             strokeWidth={1}
-            markerStart={lineColor=='green'?"url(#arrow-start-green)":"url(#arrow-start-red)"}
-            markerEnd={lineColor=='green'?"url(#arrow-end-green)":"url(#arrow-end-red)"}
+            markerStart={lineColor == 'green' ? 'url(#arrow-start-green)' : 'url(#arrow-start-red)'}
+            markerEnd={lineColor == 'green' ? 'url(#arrow-end-green)' : 'url(#arrow-end-red)'}
           />
         )}
 
@@ -211,7 +211,7 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             orient="auto"
             markerUnits="strokeWidth"
           >
-          <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
+            <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
           </marker>
         </defs>
 
@@ -238,7 +238,7 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             orient="auto"
             markerUnits="strokeWidth"
           >
-          <path d="M4,0 L4,4 L0,2 z" fill={'green'} />
+            <path d="M4,0 L4,4 L0,2 z" fill={'green'} />
           </marker>
         </defs>
         <defs>
@@ -265,7 +265,7 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             orient="auto"
             markerUnits="strokeWidth"
           >
-          <path d="M4,0 L4,4 L0,2 z" fill={'red'} />
+            <path d="M4,0 L4,4 L0,2 z" fill={'red'} />
           </marker>
         </defs>
 

--- a/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
@@ -152,7 +152,9 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
         ? 'green'
         : 'red'
       : colorScale(dataSpec[0].categoryValue);
-
+  console.log('lineColor', lineColor);
+  
+  const uid = gistvisSpec.unitSegmentSpec.insightType+'-'+gistvisSpec.unitSegmentSpec.attribute+'-'+gistvisSpec.id;
   return (
     <Tooltip title={tooltip != null ? getTooltipContnet(tooltip.value) : ''} placement="bottom" color="#ffffff">
       <svg
@@ -165,10 +167,10 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
         onMouseMove={handleMouseMove}
         onMouseOut={handleMouseOut}
       >
-        <path d={areaGenerator(dataset) || undefined} fill={`url(#${gistvisSpec.id}-areaGradient`} />
+        <path d={areaGenerator(dataset) || undefined} fill={`url(#${uid}-areaGradient`} />
         <path d={lineGenerator(dataset) || undefined} fill="none" strokeWidth={1.5} />
         <defs>
-          <linearGradient id={`${gistvisSpec.id}-areaGradient`} x1="0%" y1="0%" x2="0%" y2="100%">
+          <linearGradient id={`${uid}-areaGradient`} x1="0%" y1="0%" x2="0%" y2="100%">
             <stop offset="0%" stopColor={lineColor} stopOpacity="1" />
             <stop offset="100%" stopColor={lineColor} stopOpacity="0.2" />
           </linearGradient>
@@ -180,8 +182,8 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             fill="none"
             stroke={lineColor}
             strokeWidth={1}
-            markerStart="url(#arrow-start)"
-            markerEnd="url(#arrow-end)"
+            markerStart={lineColor=='green'?"url(#arrow-start-green)":"url(#arrow-start-red)"}
+            markerEnd={lineColor=='green'?"url(#arrow-end-green)":"url(#arrow-end-red)"}
           />
         )}
 
@@ -209,7 +211,61 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             orient="auto"
             markerUnits="strokeWidth"
           >
-            <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
+          <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
+          </marker>
+        </defs>
+
+        <defs>
+          <marker
+            id="arrow-end-green"
+            markerWidth="4"
+            markerHeight="4"
+            refX="3"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M0,0 L0,4 L4,2 z" fill={'green'} />
+          </marker>
+        </defs>
+        <defs>
+          <marker
+            id="arrow-start-green"
+            markerWidth="4"
+            markerHeight="4"
+            refX="1"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+          <path d="M4,0 L4,4 L0,2 z" fill={'green'} />
+          </marker>
+        </defs>
+        <defs>
+          <marker
+            id="arrow-end-red"
+            markerWidth="4"
+            markerHeight="4"
+            refX="3"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M0,0 L0,4 L4,2 z" fill={'red'} />
+          </marker>
+        </defs>
+
+        <defs>
+          <marker
+            id="arrow-start-red"
+            markerWidth="4"
+            markerHeight="4"
+            refX="1"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+          <path d="M4,0 L4,4 L0,2 z" fill={'red'} />
           </marker>
         </defs>
 


### PR DESCRIPTION
## Description
- fix 2 sub bugs:  gradiend color error and arrow color error.

## Why colors error
- Violation in Key Unique Principle.
- In `@src-site/modules/visualizer/wordScaleVis/lineChart.tsx` we have implemented the rendering of trend visualization. We use `url(\#${gistvisSpec.id}-xxx)` to capture elements we defines below which is to display the corresponding gradient area. When locating an element using \#, I guess it will look for elements globally or it will fails in defining an element with an existed key. But GistvisSpec.id is defined locally as GistvisSpec is an element in an paragraphSpec, which is an element in paragraphSpec[]. Although we define the GistvisSpec.id with 'p{number}s{number}' ensuring there is no problem in a paragraphSpec[], there are 6 processed articles displaying in the site page. Accidently, the 3rd article has a trend fact whose relative position is same to another trend fact has an opposite attribute before. Therefore, the linechart component show the gradient area using colors defined before.
-  In `@src-site/modules/visualizer/wordScaleVis/lineChart.tsx` we use `url(\#arrow-start)` and `url(\#arrow-end)` to capture a dynamic defined element. Same way as last bug, it only displays the color which the first defined trend-visualization has.

## What's changed
- Embed insightType and attribute into the id in LineChart component.
```
const uid = gistvisSpec.unitSegmentSpec.insightType + '-' + gistvisSpec.unitSegmentSpec.attribute + '-' + gistvisSpec.id;
```
Use uid to define the gradient element.
- Define four constant element with id `arrow-start/end-green/red` and judge the lineColor before locating the elements with id.
```
markerStart={lineColor == 'green' ? 'url(#arrow-start-green)' : 'url(#arrow-start-red)'}
markerEnd={lineColor == 'green' ? 'url(#arrow-end-green)' : 'url(#arrow-end-red)'}
```