### PR TITLE
Bugfix:  VerticalBarChart Incorrectly Highlights Multiple Bars and Displays Inaccurate Tooltips Due to Insufficiently Unique Bar Identifiers

### DIFF
--- a/site/src/modules/visualizer/wordScaleVis/vBarChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/vBarChart.tsx
@@ -52,7 +52,11 @@ const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelected
   });
 
   const getToolTipContent = () => {
-    if (!selectedEntity || selectedEntity === 'placeholder') {
+    if (hoveredUniqueId === null) {
+      return null;
+    }
+
+    if (selectedEntity === 'placeholder') {
       return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
     }
 
@@ -68,9 +72,9 @@ const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelected
           <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
             The difference between{' '}
             <span style={{ color: colorScale(refCase.categoryValue) }}>
-              {refCase.categoryValue} ({refCase.valueValue}%)
+              {refCase.categoryValue} ({refCase.valueValue})
             </span>{' '}
-            and {selectedEntity} ({currentCase.valueValue}%) is {diff}.
+            and {selectedEntity} ({currentCase.valueValue}) is {diff}.
           </div>
         );
       } else {
@@ -78,11 +82,11 @@ const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelected
           <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
             The difference between{' '}
             <span style={{ color: colorScale(refCase.categoryValue) }}>
-              {refCase.categoryValue} ({refCase.valueValue}%)
+              {refCase.categoryValue} ({refCase.valueValue})
             </span>{' '}
             and{' '}
             <span style={{ color: colorScale(selectedEntity) }}>
-              {selectedEntity} ({currentCase.valueValue}%)
+              {selectedEntity} ({currentCase.valueValue})
             </span>{' '}
             is {diff}.
           </div>
@@ -96,7 +100,7 @@ const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelected
       }
       return (
         <div style={{ lineHeight: 1.1, fontSize: '14px', color: colorScale(selectedEntity), fontWeight: 'bold' }}>
-          {rankData.valueKey + ' Rank ' + rank + ': ' + selectedEntity}
+          {rankData.valueKey + ' ' + rank + ': ' + selectedEntity}
         </div>
       );
     }

--- a/site/src/modules/visualizer/wordScaleVis/vBarChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/vBarChart.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as d3 from 'd3';
 import { SVG_HEIGHT, SVG_UNIT_WIDTH } from '../constants';
 import { ChartProps, DataSpec, InsightType } from '../types';
 import { Tooltip } from 'antd';
 
 const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }: ChartProps) => {
+  const [hoveredUniqueId, setHoveredUniqueId] = useState<string | null>(null); // 跟踪悬停条形
   const dataSpec = gistvisSpec.dataSpec ?? [];
 
   const verticalBarChartWidth = SVG_UNIT_WIDTH * dataSpec.length;
@@ -23,87 +24,79 @@ const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelected
     .range([SVG_HEIGHT, 0]);
 
   const knownCategories = dataSpec.map((d: DataSpec, i: number) => {
+    const uniqueId = `${d.categoryValue}-${d.valueKey}-${d.valueValue}`; // 包含valueValue的唯一标识符
+    const isHovered = uniqueId === hoveredUniqueId; // 检查是否悬停
     const hoverStyle = {
-      opacity: d.categoryValue === selectedEntity ? 1 : 0.5,
+      opacity: isHovered ? 1 : 0.5, // 仅高亮悬停的条形
       transition: 'opacity 0.3s',
     };
     return (
       <rect
-        key={d.categoryValue}
+        key={uniqueId} // 唯一key
         x={xScale(i)}
         y={yScale(dataset[i])}
         width={SVG_UNIT_WIDTH}
         height={SVG_HEIGHT - yScale(dataset[i])}
-        fill={d.categoryValue !== 'placeholder' ? colorScale(d.categoryValue) : 'grey'}
+        fill={d.categoryValue !== 'placeholder' ? colorScale(d.categoryValue) : 'grey'} // 颜色基于categoryValue
         style={hoverStyle}
         onMouseOver={() => {
-          setSelectedEntity(d.categoryValue);
+          setSelectedEntity(d.categoryValue); // 设置为categoryValue
+          setHoveredUniqueId(uniqueId); // 设置悬停标识符
         }}
         onMouseOut={() => {
           setSelectedEntity('');
+          setHoveredUniqueId(null);
         }}
       />
     );
   });
 
   const getToolTipContent = () => {
-    if (selectedEntity === 'placeholder') {
-      return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: 'grey',
-            fontWeight: 'bold',
-          }}
-        >
-          Rank
-        </div>
-      );
-    } else if (gistvisSpec.unitSegmentSpec.insightType === 'rank') {
-      const rank = dataSpec.filter((d) => d.categoryValue === selectedEntity)[0]?.valueValue;
-      if (rank === undefined) {
+    if (!selectedEntity || selectedEntity === 'placeholder') {
+      return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
+    }
+
+    if (gistvisSpec.unitSegmentSpec.insightType === 'comparison') {
+      const currentCase = dataSpec.find((d) => `${d.categoryValue}-${d.valueKey}-${d.valueValue}` === hoveredUniqueId);
+      if (!currentCase) {
+        return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
+      }
+      const refCase = dataSpec.find((d) => d !== currentCase) || dataSpec[0];
+      const diff = Math.abs(currentCase.valueValue - refCase.valueValue);
+      if (refCase.categoryValue === selectedEntity) {
         return (
-          <div
-            style={{
-              lineHeight: 1.1,
-              fontSize: '14px',
-              color: 'grey',
-              fontWeight: 'bold',
-            }}
-          >
-            Rank
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            The difference between{' '}
+            <span style={{ color: colorScale(refCase.categoryValue) }}>
+              {refCase.categoryValue} ({refCase.valueValue}%)
+            </span>{' '}
+            and {selectedEntity} ({currentCase.valueValue}%) is {diff}.
+          </div>
+        );
+      } else {
+        return (
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            The difference between{' '}
+            <span style={{ color: colorScale(refCase.categoryValue) }}>
+              {refCase.categoryValue} ({refCase.valueValue}%)
+            </span>{' '}
+            and{' '}
+            <span style={{ color: colorScale(selectedEntity) }}>
+              {selectedEntity} ({currentCase.valueValue}%)
+            </span>{' '}
+            is {diff}.
           </div>
         );
       }
+    } else if (gistvisSpec.unitSegmentSpec.insightType === 'rank') {
+      const rankData = dataSpec.find((d) => `${d.categoryValue}-${d.valueKey}-${d.valueValue}` === hoveredUniqueId);
+      const rank = rankData?.valueValue;
+      if (!rankData || rank === undefined) {
+        return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Rank</div>;
+      }
       return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: colorScale(selectedEntity),
-            fontWeight: 'bold',
-          }}
-        >
-          {'Rank ' + dataSpec.filter((d) => d.categoryValue === selectedEntity)[0]?.valueValue + ': ' + selectedEntity}
-        </div>
-      );
-    } else if (gistvisSpec.unitSegmentSpec.insightType === 'comparison') {
-      const refCase = dataSpec[0];
-      const currentCase = dataSpec.find((d) => d.categoryValue === selectedEntity) ?? refCase;
-      const diff = parseFloat(Math.abs(refCase.valueValue - currentCase.valueValue).toFixed(2));
-      return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: 'black',
-            fontWeight: 'bold',
-          }}
-        >
-          The difference between{' '}
-          <span style={{ color: colorScale(refCase.categoryValue) }}>{refCase.categoryValue}</span> and{' '}
-          <span style={{ color: colorScale(selectedEntity) }}>{selectedEntity}</span> is {diff}.
+        <div style={{ lineHeight: 1.1, fontSize: '14px', color: colorScale(selectedEntity), fontWeight: 'bold' }}>
+          {rankData.valueKey + ' Rank ' + rank + ': ' + selectedEntity}
         </div>
       );
     }

--- a/site/src/modules/visualizer/wordScaleVis/vBarChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/vBarChart.tsx
@@ -5,7 +5,7 @@ import { ChartProps, DataSpec, InsightType } from '../types';
 import { Tooltip } from 'antd';
 
 const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }: ChartProps) => {
-  const [hoveredUniqueId, setHoveredUniqueId] = useState<string | null>(null); // 跟踪悬停条形
+  const [hoveredUniqueId, setHoveredUniqueId] = useState<string | null>(null);
   const dataSpec = gistvisSpec.dataSpec ?? [];
 
   const verticalBarChartWidth = SVG_UNIT_WIDTH * dataSpec.length;
@@ -24,24 +24,24 @@ const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelected
     .range([SVG_HEIGHT, 0]);
 
   const knownCategories = dataSpec.map((d: DataSpec, i: number) => {
-    const uniqueId = `${d.categoryValue}-${d.valueKey}-${d.valueValue}`; // 包含valueValue的唯一标识符
-    const isHovered = uniqueId === hoveredUniqueId; // 检查是否悬停
+    const uniqueId = `${d.categoryValue}-${d.valueKey}-${d.valueValue}`;
+    const isHovered = uniqueId === hoveredUniqueId;
     const hoverStyle = {
-      opacity: isHovered ? 1 : 0.5, // 仅高亮悬停的条形
+      opacity: isHovered ? 1 : 0.5,
       transition: 'opacity 0.3s',
     };
     return (
       <rect
-        key={uniqueId} // 唯一key
+        key={uniqueId}
         x={xScale(i)}
         y={yScale(dataset[i])}
         width={SVG_UNIT_WIDTH}
         height={SVG_HEIGHT - yScale(dataset[i])}
-        fill={d.categoryValue !== 'placeholder' ? colorScale(d.categoryValue) : 'grey'} // 颜色基于categoryValue
+        fill={d.categoryValue !== 'placeholder' ? colorScale(d.categoryValue) : 'grey'}
         style={hoverStyle}
         onMouseOver={() => {
-          setSelectedEntity(d.categoryValue); // 设置为categoryValue
-          setHoveredUniqueId(uniqueId); // 设置悬停标识符
+          setSelectedEntity(d.categoryValue);
+          setHoveredUniqueId(uniqueId);
         }}
         onMouseOut={() => {
           setSelectedEntity('');


### PR DESCRIPTION
#### **Description**
This PR resolves two critical bugs in the `VerticalBarChart` component related to bar highlighting and tooltip accuracy:
- **Synchronized Highlighting**: Previously, bars with the same `categoryValue` (e.g., "U.S.") or both identical `categoryValue` and `valueKey` (e.g., "Black women" with "Favorable opinion percentage") highlighted simultaneously when hovered, preventing independent interaction with individual bars.
- **Tooltip Inaccuracies**: Tooltips displayed incorrect or incomplete data when multiple bars shared the same `categoryValue` and `valueKey`, failing to reflect the specific `valueValue` of the hovered bar.

The implementation introduces a unique identifier (`uniqueId`) that includes `valueValue` to distinguish each bar, ensuring independent highlighting and accurate tooltip content, while maintaining compatibility with the existing `setSelectedEntity` logic tied to `categoryValue`.

#### **Solution**
- **Unique Identifier for Bars**:  
  A new `uniqueId` is defined as `${d.categoryValue}-${d.valueKey}-${d.valueValue}` (e.g., "Black women-Favorable opinion percentage-67"), enabling precise identification of each bar. This is tracked via a new state variable, `hoveredUniqueId`, to control hover interactions independently of `selectedEntity`.
- **Enhanced Tooltip Logic**:  
  The tooltip now uses `hoveredUniqueId` to retrieve the exact data of the hovered bar (`currentCase`), ensuring the correct `valueValue` is displayed. In `comparison` mode, it compares this with a reference case (`refCase`), dynamically showing the difference while emphasizing `selectedEntity` (set to `d.categoryValue`) for consistency with color and context.

These changes fix the synchronized highlighting and tooltip issues, improving usability and data accuracy in both `rank` and `comparison` modes.

#### **Changes**
- **`@site/src/components/VerticalBarChart.tsx`**:
  - **Added `hoveredUniqueId` State**: Introduced `const [hoveredUniqueId, setHoveredUniqueId] = useState<string | null>(null)` to track the hovered bar uniquely.
  - **Updated Bar Rendering**: Modified bar elements to use `uniqueId = ${d.categoryValue}-${d.valueKey}-${d.valueValue}` for keys and hover logic, ensuring independent highlighting via `isHovered = uniqueId === hoveredUniqueId`.
  - **Adjusted Hover Events**: Updated `onMouseOver` to set both `setSelectedEntity(d.categoryValue)` and `setHoveredUniqueId(uniqueId)`, and `onMouseOut` to clear both, maintaining existing functionality while enabling precise hover control.
  - **Enhanced `getToolTipContent` Function**: 
    - In `comparison` mode, retrieves `currentCase` using `hoveredUniqueId` and calculates the difference with `refCase` (another data point or the first entry if none exists).
    - Formatting the tooltip as "The difference between {refCase.categoryValue} ({refCase.valueValue}%) and {selectedEntity} ({currentCase.valueValue}%) is {diff}".
    - In `rank` mode, preserves accurate ranking display based on `hoveredUniqueId`.