### PR TITLE
Visualizer modification: To support the invariant trend

### DIFF
--- a/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
+++ b/site/src/modules/visualizer/renderer/trendTextRenderer.tsx
@@ -21,6 +21,13 @@ const dummyDataMap: { [key in TrendAttribute]: DataPoint[] } = {
     { x: 4, y: 6 },
     { x: 5, y: 1 },
   ],
+  invariable: [
+    { x: 1, y: 20 },
+    { x: 2, y: 25 },
+    { x: 3, y: 20 },
+    { x: 4, y: 15 },
+    { x: 5, y: 20 },
+  ],
 };
 
 const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
@@ -39,7 +46,7 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
 
   const hasNaN = dataSpec.some((d) => isNaN(d.valueValue));
   const numEntries = dataSpec.length;
-  const validForNominalTrend = attribute === 'negative' || attribute === 'positive';
+  const validForNominalTrend = attribute === 'negative' || attribute === 'positive' || attribute === 'invariable';
   const lineChartType: TrendOptions =
     validForNominalTrend && (hasNaN || numEntries === 0)
       ? 'nominal'
@@ -64,6 +71,13 @@ const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
         return [
           { x: 0, y: low },
           { x: 1, y: high },
+        ];
+      } else if (attribute === 'invariable') {
+        // use average value
+        const avg = (high + low) / 2;
+        return [
+          { x: 0, y: avg },
+          { x: 1, y: avg },
         ];
       } else {
         // actual

--- a/site/src/modules/visualizer/types.ts
+++ b/site/src/modules/visualizer/types.ts
@@ -3,7 +3,7 @@ export type VisInsightType = 'comparison' | 'trend' | 'rank' | 'proportion' | 'e
 export type InsightType = VisInsightType | 'noType';
 
 export type ExtremeAttribute = 'maximum' | 'minimum';
-export type TrendAttribute = 'positive' | 'negative';
+export type TrendAttribute = 'positive' | 'negative' | 'invariable';
 export type Attribute = ExtremeAttribute | TrendAttribute;
 
 export type DataSpec = {

--- a/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
+++ b/site/src/modules/visualizer/wordScaleVis/lineChart.tsx
@@ -38,7 +38,10 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
   const lineGenerator = d3
     .line<{ x: number; y: number }>()
     .x((d) => xScale(d.x))
-    .y((d) => yScale(d.y));
+    .y((d) => yScale(d.y))
+    .curve(gistvisSpec.unitSegmentSpec.attribute === 'invariable' 
+      ? d3.curveMonotoneX 
+      : d3.curveLinear); 
 
   const lineGeneratorDifference = d3
     .line<{ x: number; y: number }>()
@@ -62,7 +65,11 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             fontWeight: 'bold',
           }}
         >
-          {gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increasing' : '↘ decreasing'}
+          {gistvisSpec.unitSegmentSpec.attribute === 'positive' 
+          ? '↗ increasing' 
+          : gistvisSpec.unitSegmentSpec.attribute === 'negative'
+            ? '↘ decreasing'
+            : '→ stable'}
         </div>
       );
     } else if (type === 'trending') {
@@ -94,8 +101,11 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             dataSpec.find((d) => d.valueValue === selectionVal)?.categoryValue +
             ': ' +
             selectionVal}
-          . The {gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increase' : '↘ decrease'} is{' '}
-          {Math.abs(dataSpec[1].valueValue - dataSpec[0].valueValue)}.
+          {gistvisSpec.unitSegmentSpec.attribute === 'invariable' 
+            ? '. The value remains stable.'
+            : `. The ${gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increase' : '↘ decrease'} is ${
+                Math.abs(dataSpec[1].valueValue - dataSpec[0].valueValue)
+              }.`}
         </div>
       );
     } else {
@@ -150,7 +160,9 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
     type === 'nominal' || type === 'trending' || type === 'start-end'
       ? gistvisSpec.unitSegmentSpec.attribute === 'positive'
         ? 'green'
-        : 'red'
+        : gistvisSpec.unitSegmentSpec.attribute === 'negative'
+        ? 'red'
+        : 'grey'
       : colorScale(dataSpec[0].categoryValue);
 
   return (
@@ -173,6 +185,20 @@ const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, se
             <stop offset="100%" stopColor={lineColor} stopOpacity="0.2" />
           </linearGradient>
         </defs>
+
+        {gistvisSpec.unitSegmentSpec.attribute === 'invariable' && (
+          <g>
+            <line
+              x1={SVG_PADDING}
+              y1={lineChartHeight / 2}
+              x2={lineChartWidth - SVG_PADDING}
+              y2={lineChartHeight / 2}
+              stroke="grey"
+              strokeWidth={1}
+              strokeDasharray="4,4"
+            />
+          </g>
+        )}
 
         {type === 'trending' && (
           <path


### PR DESCRIPTION
The relevant parts in the visualizer have been modified to support the visualization of invariant trends. However, due to the incorrect identification of some invariant trends by LLM, they have not been displayed in the test articles yet.