### PR TITLE
Vake/visualizer2package/refactor to gistwsv

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:gist-wsv": "cd packages/gist-wsv && pnpm run build"
   },
   "keywords": [],
   "author": "",

--- a/packages/gist-wsv/README.md
+++ b/packages/gist-wsv/README.md
@@ -1,50 +1,19 @@
-# React + TypeScript + Vite
+# GistVis Word-Scale Visualization
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This package provides word-scale visualization components built with React + TypeScript + Vite.
 
-Currently, two official plugins are available:
+## Installation
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+To install the package dependencies, run:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+pnpm install
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+## Build
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
+To build the package, run:
 
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+```bash
+pnpm build
 ```

--- a/packages/gist-wsv/package.json
+++ b/packages/gist-wsv/package.json
@@ -24,7 +24,9 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@ant-design/icons": ">=5.0.0",
     "@eslint/js": "^9.19.0",
+    "@types/d3": "^7.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.3.4",
@@ -33,6 +35,7 @@
     "eslint": "^9.19.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
+    "fuse.js": ">=6.0.0",
     "globals": "^15.14.0",
     "typescript": "5.7.3",
     "typescript-eslint": "^8.22.0",

--- a/packages/gist-wsv/package.json
+++ b/packages/gist-wsv/package.json
@@ -28,11 +28,13 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "antd": "^5.16.0",
+    "d3": "^7.9.0",
     "eslint": "^9.19.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.14.0",
-    "typescript": "~4.9.5",
+    "typescript": "5.7.3",
     "typescript-eslint": "^8.22.0",
     "vite": "^6.1.0"
   }

--- a/packages/gist-wsv/package.json
+++ b/packages/gist-wsv/package.json
@@ -3,9 +3,19 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "main": "./dist/gist-wsv.umd.js",
+  "module": "./dist/gist-wsv.es.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/gist-wsv.es.js",
+      "require": "./dist/gist-wsv.umd.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/packages/gist-wsv/src/App.tsx
+++ b/packages/gist-wsv/src/App.tsx
@@ -1,35 +1,15 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import React from 'react'
 
-function App() {
-  const [count, setCount] = useState(0)
+export interface GistViewerProps {
+  text?: string
+}
 
+export const GistViewer: React.FC<GistViewerProps> = ({ text = "Hello from gist-wsv!" }) => {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div style={{ padding: '20px', border: '1px solid #ccc', borderRadius: '4px' }}>
+      {text}
+    </div>
   )
 }
 
-export default App
+export default GistViewer

--- a/packages/gist-wsv/src/components/llm/types.ts
+++ b/packages/gist-wsv/src/components/llm/types.ts
@@ -1,0 +1,19 @@
+import { DataSpec, InsightType } from '../visualizer/types';
+
+export type GistFactTypeAnnotation = {
+  id?: string;
+  text?: string;
+  type: InsightType; // should be one of the fact types
+};
+
+export interface ExtractorType {
+  dataSpec?: DataSpec[];
+  pos?: string[];
+  attribute?: string;
+}
+
+export type GistFactKnowledgeBase = {
+  definition: string;
+  examples: string[];
+  negativeExamples: string[];
+};

--- a/packages/gist-wsv/src/components/llm/visKB.ts
+++ b/packages/gist-wsv/src/components/llm/visKB.ts
@@ -1,0 +1,125 @@
+import { InsightType, VisInsightType } from '../visualizer/types';
+import { GistFactKnowledgeBase } from './types';
+import lodash from 'lodash';
+
+export const SystemInstruction = `You are a professional text preprocessing assistant specializing in text visualization.
+  Please provide a well-structured response to the user's chunk of the text strictly according to rules. 
+  The user's goal is to generate corresponding charts based on your response.\n
+  `;
+
+export const ExtractorSystemInstruction = `
+  You must extract entities, numerical values, and other content from text blocks as requested.
+  `;
+
+export function getTypeCheckerSystemInstruction(type: InsightType) {
+  const gistType = type as string;
+  const prompt = `To achieve this, please check if the text provided by the user contains ${gistType} relationship.
+      If included, type is ${gistType}; if not included, type is null.\n`;
+  return prompt;
+}
+
+// not used because it is not producing effective few-shot examples (for some reason)
+export function generateFewShotExample(
+  type: VisInsightType,
+  positiveExample: number = 2,
+  nullExample: number = 1,
+  isRandomSample: boolean = false
+) {
+  const getExample = (sentence: string, type: string) => {
+    return `User: ${sentence}
+    Assistant: """Type: ${type}"""`;
+  };
+
+  const positiveExamples = lodash
+    .sampleSize(gistKB[type].examples || [], positiveExample)
+    .map((sentence) => getExample(sentence, type as string));
+
+  let nullExamples: string[] = [];
+  if (!isRandomSample) {
+    nullExamples = lodash
+      .sampleSize(gistKB[type]?.negativeExamples || [])
+      .map((sentence) => getExample(sentence, 'null'));
+  } else {
+    const otherTypes = Object.keys(gistKB).filter((key) => key !== type);
+    nullExamples = lodash
+      .sampleSize(lodash.flatten(otherTypes.map((key) => gistKB[key as VisInsightType]?.examples || [])), nullExample)
+      .map((sentence) => getExample(sentence, 'null'));
+  }
+
+  const fewShotPrompt = [...positiveExamples, ...nullExamples].join('\n');
+  // console.log(fewShotPrompt);
+  return fewShotPrompt;
+}
+
+export const gistKB: { [key in VisInsightType]: GistFactKnowledgeBase } = {
+  comparison: {
+    definition: `
+      Comparisons is deﬁned on a 4-tuple (Xi, Dj, f , ∂ ).∀ xm, xn ∈ Xi, fD j(xm,xn) ≥ ∂ where f calculates the distance between xm and xn on Dj.
+      Typically, comparisons involve two or more entities or values that exhibit significant differences. 
+      Comparative relationships are often expressed in phrases containing multiple entities or values that highlight notable disparities.
+      Generally, sentences containing multiple sets of data are more suitable for this type and focus on difference.`,
+    examples: [
+      `China on Wednesday posted a robust GDP growth of 5.2 percent for 2023, successfully beating the government's pre-set yearly target of around 5 percent.`,
+      `There are more blocked beds in the Royal London Hospital compared with the UK average.`,
+    ],
+    negativeExamples: [`The little boy was careful enough to come first in the exam.`],
+  },
+  // Trend presents a general tendency over a time segment.
+
+  trend: {
+    definition: `
+      Trend is deﬁned on a 6-tuple (Xi, Dj, T, t1, t2, R). R describes the movement feature of VDj(Xi) on T in the segment deﬁned by t1 and t2. T is usually a temporal attribute.
+      Temporal changes usually consist of an entity and a phrase with changing semantics such as "increase", "decrease" or "rise", sometimes with numerical values.`,
+    examples: [
+      `China's population decreased by 2.08 million people in 2023 to 1.40967 billion.`,
+      `The budget for the Border Patrol Program has been rising from 1990 to 2013.`,
+    ],
+    negativeExamples: [`The little boy was careful enough to come first in the exam.`],
+  },
+  // association:
+  //   "Association refers to the useful relationship between two data attributes or among multiple attributes and can be categorized as positive, negative, or neutral sentiment.",
+  rank: {
+    definition: `
+      Rank is deﬁned on a 4-tuple (xm, Xi, dn, R). Ris the order of Vdn(xm) in sorted Vdn(Xi).
+      Rank refers to sorting the data attributes based on their values and showing the position of selected data attributes. 
+      Rank usually includes entities and their corresponding sorting, which can be numbers such as 1 and NO.2, as well as letters and words such as "great" and "A level".`,
+    examples: [
+      `The little boy was careful enough to come first in the exam.`,
+      `The top reason for consumers to engage in showrooming is (the) price (is) better online.`,
+    ],
+    negativeExamples: [`China's population decreased by 2.08 million people in 2023 to 1.40967 billion.`],
+  },
+  proportion: {
+    definition: `
+    Proportion refers to measuring the proportion of selected data attribute(s) within a specified set. Proportions are usually a ratio or a fraction of one component compared to the whole, usually with phrases nearby that indicate proportion, such as "account for".
+    If the decimals in the sentence point to the same whole, especially when the sum of these decimals is 1, it is more likely to belong to this type. Otherwise, it is more likely to belong to comparisons/ranks.`,
+    examples: [
+      `Traffic is one of the biggest sources of carbon pollution in the country and accounts for 28% of the nation's greenhouse gas emissions.`,
+      `Protein takes 66% of the diet on Sunday.`,
+    ],
+    negativeExamples: [`The little boy was careful enough to come first in the exam.`],
+  },
+  extreme: {
+    definition: `
+    Extreme is deﬁned on a 3-tuple (xm, Xi, dn).  ∀ xl ∈ Xi and xl = xm, V dn(xm) ≥ Vdn(xl) or ∀ xl ∈ Xi and xl = xm, V dn(xm) ≤ Vdn(xl).
+    Extreme refers to the extreme data cases along with the data attributes or within a certain range, can only be maximum and minimum. Notice that anomalies are individual data points and do not include trends such as "increase".`,
+    examples: [
+      `The character with the most epigrams in the collected dataset is Oscar Wilde himself, who has 12.`,
+      `The minimum wage is just $7.25.`,
+    ],
+    negativeExamples: [`The little boy was careful enough to come first in the exam.`],
+  },
+  // anomaly:
+  //   "Anomalies are usually data points that are significantly different from expected patterns.",
+  value: {
+    definition: `
+    Derived value is deﬁned on a 3-tuple (Xi, dn, R) where R is a derived value of Xi on dn. When Xi contains only 1 element, R is the value of the element on dn.
+    Values are usually numerical valuesthat have a significant impact on entities.`,
+    // with special meanings
+    examples: [
+      `46 horses have won two out of three Triple Crown Races.`,
+      `40 cities and counties also are hiking their minimum wages.`,
+    ],
+    negativeExamples: [`The little boy was careful enough to come first in the exam.`],
+  },
+};

--- a/packages/gist-wsv/src/components/visualizer/constants.ts
+++ b/packages/gist-wsv/src/components/visualizer/constants.ts
@@ -1,0 +1,7 @@
+export const SVG_WIDTH = 90;
+export const SVG_UNIT_WIDTH = 12;
+export const SVG_HEIGHT = 20;
+export const SVG_PADDING = 2;
+
+export const SCALE_CONST = 2;
+export const SVG_INTERVAL = 5;

--- a/packages/gist-wsv/src/components/visualizer/props.ts
+++ b/packages/gist-wsv/src/components/visualizer/props.ts
@@ -1,0 +1,8 @@
+import { DataSpec } from './types';
+
+export interface HorizontalStackedBarProps {
+  dataSpec: DataSpec[];
+  colorScale: d3.ScaleOrdinal<string, string, never>;
+  selectedEntity: string;
+  setSelectedEntity: (entity: string) => void;
+}

--- a/packages/gist-wsv/src/components/visualizer/renderer/comparisonTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/comparisonTextRenderer.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { DataSpec, EntitySpec, GistvisSpec } from '../types';
+import * as d3 from 'd3';
+import HoverText from '../widgets/hoverText';
+import { VerticalBarChart } from '../wordScaleVis/chartList';
+import { getHighlightPos, getProductionVisSpec, getUniqueEntities } from '../utils/postProcess';
+import useTrackVisit from '../utils/useTrack';
+
+const ComparisonTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const id = gistvisSpec.id;
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('comp-' + id);
+  const [currentEntity, setCurrentEntity] = useState<string>('');
+
+  // check entity counts in the dataSpec, if 2 and one valueValue is 0, transform data for better visualization
+  let dataSpec: DataSpec[] = gistvisSpec.dataSpec ?? [];
+  if (dataSpec.length < 2) {
+    console.warn('Not enough data entities to perform transformation.');
+  } else if (dataSpec.length === 2) {
+    const hasZeroValue = dataSpec.some((d) => d.valueValue === 0);
+    if (hasZeroValue) {
+      const maxValue = Math.max(...dataSpec.map((d) => d.valueValue));
+      dataSpec = dataSpec.map((d) => ({
+        ...d,
+        valueValue: maxValue + d.valueValue,
+      }));
+    }
+  }
+
+  const gistvisSpecForVis = {
+    ...gistvisSpec,
+    dataSpec: dataSpec,
+  };
+
+  const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  const uniqueEntities = getUniqueEntities(entityPos);
+
+  const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos);
+
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
+
+  const rankVis = (
+    <VerticalBarChart
+      gistvisSpec={gistvisSpecForVis}
+      colorScale={colorScale}
+      selectedEntity={currentEntity}
+      setSelectedEntity={setCurrentEntity}
+    />
+  );
+
+  return (
+    <span data-component-id={identifier}>
+      {vis.map((content, index) => {
+        if (content.displayType === 'text') {
+          return <span key={index}>{content.content}</span>;
+        } else if (content.displayType === 'entity') {
+          return (
+            <HoverText
+              key={index}
+              text={content.content}
+              isHovered={content.entity === currentEntity}
+              color={colorScale(content.entity ?? 'grey')}
+              onMouseOver={() => {
+                handleMouseEnter();
+                setCurrentEntity(content.entity ?? '');
+              }}
+              onMouseOut={() => {
+                handleMouseLeave();
+                setCurrentEntity('');
+              }}
+            />
+          );
+        } else if (content.displayType === 'word-scale-vis') {
+          return (
+            <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+              <span key={index}>
+                {content.content}
+                {rankVis}
+              </span>
+            </span>
+          );
+        }
+      })}
+    </span>
+  );
+};
+
+export default ComparisonTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/renderer/extremeTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/extremeTextRenderer.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { EntitySpec, GistvisSpec } from '../types';
+import * as d3 from 'd3';
+import HoverText from '../widgets/hoverText';
+import { GlyphMaxMin } from '../wordScaleVis/chartList';
+import { getHighlightPos, getProductionVisSpec, getUniqueEntities } from '../utils/postProcess';
+import useTrackVisit from '../utils/useTrack';
+
+const ExtremeTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const id = gistvisSpec.id;
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('extreme-' + id);
+  const [currentEntity, setCurrentEntity] = useState<string>('');
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+
+  const inSituPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'phrase');
+  const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  const uniqueEntities = getUniqueEntities(entityPos);
+
+  const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, inSituPos, 'left');
+
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
+
+  const proportionVis = (
+    <GlyphMaxMin
+      gistvisSpec={gistvisSpec}
+      colorScale={colorScale}
+      selectedEntity={currentEntity}
+      setSelectedEntity={setCurrentEntity}
+    />
+  );
+
+  return (
+    <span data-component-id={identifier}>
+      {vis.map((content, index) => {
+        if (content.displayType === 'text') {
+          return <span key={index}>{content.content}</span>;
+        } else if (content.displayType === 'entity') {
+          return (
+            <HoverText
+              key={index}
+              text={content.content}
+              isHovered={content.entity === currentEntity}
+              color={colorScale(content.entity ?? 'grey')}
+              onMouseOver={() => {
+                handleMouseEnter();
+                setCurrentEntity(content.entity ?? '');
+              }}
+              onMouseOut={() => {
+                handleMouseLeave();
+                setCurrentEntity('');
+              }}
+            />
+          );
+        } else if (content.displayType === 'word-scale-vis') {
+          return (
+            <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+              <span key={index}>
+                {content.content}
+                {proportionVis}
+              </span>
+            </span>
+          );
+        }
+      })}
+    </span>
+  );
+};
+
+export default ExtremeTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/renderer/plainTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/plainTextRenderer.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { GistvisSpec } from '../types';
+
+const PlainTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const endingPunctuation = gistvisSpec.unitSegmentSpec.context[gistvisSpec.unitSegmentSpec.context.length - 1] + ' ';
+  return (
+    <span>
+      {gistvisSpec.unitSegmentSpec.context.slice(0, -1)}
+      {endingPunctuation}
+    </span>
+  );
+};
+
+export default PlainTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/renderer/proportionTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/proportionTextRenderer.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { EntitySpec, GistvisSpec } from '../types';
+import * as d3 from 'd3';
+import HoverText from '../widgets/hoverText';
+import { HorizontalStackedBarChart } from '../wordScaleVis/chartList';
+import { getHighlightPos, getProductionVisSpec, getUniqueEntities } from '../utils/postProcess';
+import useTrackVisit from '../utils/useTrack';
+
+const ProportionTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const id = gistvisSpec.id;
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('prop-' + id);
+  const [currentEntity, setCurrentEntity] = useState<string>('');
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+
+  const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  const uniqueEntities = getUniqueEntities(entityPos);
+  const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos);
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
+
+  const proportionVis = (
+    <HorizontalStackedBarChart
+      gistvisSpec={gistvisSpec}
+      colorScale={colorScale}
+      selectedEntity={currentEntity}
+      setSelectedEntity={setCurrentEntity}
+    />
+  );
+
+  return (
+    <span data-component-id={identifier}>
+      {vis.map((content, index) => {
+        if (content.displayType === 'text') {
+          return <span key={index}>{content.content}</span>;
+        } else if (content.displayType === 'entity') {
+          return (
+            <HoverText
+              key={index}
+              text={content.content}
+              isHovered={content.entity === currentEntity}
+              color={colorScale(content.entity ?? 'grey')}
+              onMouseOver={() => {
+                handleMouseEnter();
+                setCurrentEntity(content.entity ?? '');
+              }}
+              onMouseOut={() => {
+                handleMouseLeave();
+                setCurrentEntity('');
+              }}
+            />
+          );
+        } else if (content.displayType === 'word-scale-vis') {
+          return (
+            <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+              <span key={index}>
+                {content.content}
+                {proportionVis}
+              </span>
+            </span>
+          );
+        }
+      })}
+    </span>
+  );
+};
+
+export default ProportionTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/renderer/rankTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/rankTextRenderer.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { DataSpec, EntitySpec, GistvisSpec } from '../types';
+import * as d3 from 'd3';
+import lodash from 'lodash';
+import HoverText from '../widgets/hoverText';
+import { VerticalBarChart } from '../wordScaleVis/chartList';
+import { getHighlightPos, getProductionVisSpec, getUniqueEntities } from '../utils/postProcess';
+import useTrackVisit from '../utils/useTrack';
+
+const addPlaceholders = (dataSpec: DataSpec[], maxRank: number) => {
+  const existingRanks = dataSpec.map((item) => item.valueValue);
+  const placeholders = Array.from({ length: maxRank }, (_, i) => i + 1)
+    .filter((rank) => !existingRanks.includes(rank))
+    .map((rank) => ({
+      categoryKey: dataSpec[0].categoryKey,
+      categoryValue: 'placeholder',
+      valueKey: dataSpec[0].valueKey,
+      valueValue: rank,
+    }));
+  return [...dataSpec, ...placeholders];
+};
+
+const ensureMinimumLength = (dataSpec: DataSpec[], minLength: number) => {
+  if (dataSpec.length < minLength) {
+    const additionalData = Array.from({ length: minLength - dataSpec.length }, (_, i) => ({
+      categoryKey: dataSpec[0].categoryKey,
+      categoryValue: 'placeholder',
+      valueKey: dataSpec[0].valueKey,
+      valueValue: dataSpec.length + i + 1,
+    }));
+    return [...dataSpec, ...additionalData];
+  }
+  return dataSpec;
+};
+
+const RankTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const id = gistvisSpec.id;
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('rank-' + id);
+  const [currentEntity, setCurrentEntity] = useState<string>('');
+
+  // check entity counts in the dataSpec, if less than 3, add dummy data
+  let dataSpec: DataSpec[] = gistvisSpec.dataSpec ? gistvisSpec.dataSpec : [];
+  // get maximum valueValue
+  const existingRanks = dataSpec.map((d) => d.valueValue);
+  const maxRank = Math.max(...existingRanks);
+
+  // if the length and maxRank does not match, fill in the rest with placeholder
+  if (dataSpec.length !== maxRank && dataSpec.length > 0) {
+    dataSpec = addPlaceholders(dataSpec, maxRank);
+  }
+  // sort dataSpec
+  dataSpec = lodash.orderBy(dataSpec, ['valueValue'], ['asc']);
+  // ensure ranking vis has at least 3 items
+  dataSpec = ensureMinimumLength(dataSpec, 3);
+
+  const gistvisSpecForVis = {
+    ...gistvisSpec,
+    dataSpec: dataSpec,
+  };
+
+  const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  const uniqueEntities = getUniqueEntities(entityPos);
+
+  const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos);
+
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
+
+  const rankVis = (
+    <VerticalBarChart
+      gistvisSpec={gistvisSpecForVis}
+      colorScale={colorScale}
+      selectedEntity={currentEntity}
+      setSelectedEntity={setCurrentEntity}
+    />
+  );
+
+  return (
+    <span data-component-id={identifier}>
+      {vis.map((content, index) => {
+        if (content.displayType === 'text') {
+          return <span key={index}>{content.content}</span>;
+        } else if (content.displayType === 'entity') {
+          return (
+            <HoverText
+              key={index}
+              text={content.content}
+              isHovered={content.entity === currentEntity}
+              color={colorScale(content.entity ?? 'grey')}
+              onMouseOver={() => {
+                handleMouseEnter();
+                setCurrentEntity(content.entity ?? '');
+              }}
+              onMouseOut={() => {
+                handleMouseLeave();
+                setCurrentEntity('');
+              }}
+            />
+          );
+        } else if (content.displayType === 'word-scale-vis') {
+          return (
+            <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+              <span key={index}>
+                {content.content}
+                {rankVis}
+              </span>
+            </span>
+          );
+        }
+      })}
+    </span>
+  );
+};
+
+export default RankTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/renderer/renderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/renderer.tsx
@@ -1,0 +1,70 @@
+import '../../../style/page.css';
+import { GistvisSpec, InsightType, paragraphSpec } from '../types';
+import {
+  ComparisonTextRenderer,
+  ExtremeTextRenderer,
+  PlainTextRenderer,
+  ProportionTextRenderer,
+  RankTextRenderer,
+  ValueTextRenderer,
+  TrendTextRenderer,
+} from './rendererList';
+import { recommendValidTypes } from '../utils/utils';
+import FallBackCase from '../widgets/fallbackVis';
+
+const ArtcleProcess = ({ llmarticle }: { llmarticle: paragraphSpec[] }) => {
+  const renderMap = {
+    noType: (item: GistvisSpec) => <PlainTextRenderer gistvisSpec={item} />,
+    trend: (item: GistvisSpec) => <TrendTextRenderer gistvisSpec={item} />,
+    rank: (item: GistvisSpec) => <RankTextRenderer gistvisSpec={item} />,
+    proportion: (item: GistvisSpec) => <ProportionTextRenderer gistvisSpec={item} />,
+    comparison: (item: GistvisSpec) => <ComparisonTextRenderer gistvisSpec={item} />,
+    extreme: (item: GistvisSpec) => <ExtremeTextRenderer gistvisSpec={item} />,
+    value: (item: GistvisSpec) => <ValueTextRenderer gistvisSpec={item} />,
+    fallback: (item: GistvisSpec) => <FallBackCase gistvisSpec={item} />,
+  };
+  // console.log(JSON.stringify(llmarticle, null, 2))
+
+  const checkDataspecValidity = (item: GistvisSpec) => {
+    const dataSpec = item.dataSpec ?? [];
+    // if (dataSpec.length === 0) {
+    //   return false;
+    // }
+    // else {
+    //   let categoryKeyList = lodash.uniq(dataSpec.map((data) => data.categoryKey));
+    //   let valueKeyList = lodash.uniq(dataSpec.map((data) => data.valueKey));
+    //   if (categoryKeyList.length > 1 || valueKeyList.length > 1) {
+    //     return false;
+    //   }
+    //   else {
+    return true;
+    //   }
+    // }
+  };
+
+  return (
+    <div style={{ textAlign: 'justify' }}>
+      {llmarticle.map((para) => {
+        return (
+          <p key={para.paragraphIdx}>
+            {para.paragraphContent.map((item) => {
+              const recommendedTypes = recommendValidTypes(item);
+              const renderType = recommendedTypes.includes(item.unitSegmentSpec.insightType)
+                ? item.unitSegmentSpec.insightType
+                : 'fallback';
+
+              let finalRenderType: InsightType | 'fallback' = renderType;
+              if (renderType !== 'noType' && renderType !== 'fallback' && !checkDataspecValidity(item)) {
+                finalRenderType = 'fallback';
+              }
+              const renderFunction = renderMap[finalRenderType];
+              return renderFunction ? renderFunction(item) : null;
+            })}
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ArtcleProcess;

--- a/packages/gist-wsv/src/components/visualizer/renderer/rendererList.ts
+++ b/packages/gist-wsv/src/components/visualizer/renderer/rendererList.ts
@@ -1,0 +1,7 @@
+export { default as PlainTextRenderer } from './plainTextRenderer';
+export { default as ProportionTextRenderer } from './proportionTextRenderer';
+export { default as RankTextRenderer } from './rankTextRenderer';
+export { default as ExtremeTextRenderer } from './extremeTextRenderer';
+export { default as ComparisonTextRenderer } from './comparisonTextRenderer';
+export { default as ValueTextRenderer } from './valueTextRenderer';
+export { default as TrendTextRenderer } from './trendTextRenderer';

--- a/packages/gist-wsv/src/components/visualizer/renderer/trendTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/trendTextRenderer.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import { DataPoint, EntitySpec, GistvisSpec, TrendAttribute, TrendOptions } from '../types';
+import * as d3 from 'd3';
+import HoverText from '../widgets/hoverText';
+import { LineChart } from '../wordScaleVis/chartList';
+import { getHighlightPos, getProductionVisSpec, getUniqueEntities } from '../utils/postProcess';
+import useTrackVisit from '../utils/useTrack';
+
+const dummyDataMap: { [key in TrendAttribute]: DataPoint[] } = {
+  positive: [
+    { x: 1, y: 1 },
+    { x: 2, y: 6 },
+    { x: 3, y: 20 },
+    { x: 4, y: 40 },
+    { x: 5, y: 80 },
+  ],
+  negative: [
+    { x: 1, y: 80 },
+    { x: 2, y: 40 },
+    { x: 3, y: 20 },
+    { x: 4, y: 6 },
+    { x: 5, y: 1 },
+  ],
+  invariable: [
+    { x: 1, y: 20 },
+    { x: 2, y: 25 },
+    { x: 3, y: 20 },
+    { x: 4, y: 15 },
+    { x: 5, y: 20 },
+  ],
+};
+
+const TrendTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const id = gistvisSpec.id;
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('trend-' + id);
+  const [currentEntity, setCurrentEntity] = useState<string>('');
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+  const attribute = (gistvisSpec.unitSegmentSpec.attribute as TrendAttribute) ?? '';
+
+  const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  const uniqueEntities = getUniqueEntities(entityPos);
+
+  const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos);
+
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
+
+  const hasNaN = dataSpec.some((d) => isNaN(d.valueValue));
+  const numEntries = dataSpec.length;
+  const validForNominalTrend = attribute === 'negative' || attribute === 'positive' || attribute === 'invariable';
+  const lineChartType: TrendOptions =
+    validForNominalTrend && (hasNaN || numEntries === 0)
+      ? 'nominal'
+      : validForNominalTrend && !hasNaN && numEntries === 1
+        ? 'trending'
+        : validForNominalTrend && !hasNaN && numEntries === 2
+          ? 'start-end'
+          : 'actual';
+
+  const transformData = (): DataPoint[] => {
+    if (lineChartType === 'nominal' || lineChartType === 'trending') {
+      return dummyDataMap[attribute];
+    } else if (lineChartType === 'start-end') {
+      const low = d3.min(dataSpec, (d) => d.valueValue) as number;
+      const high = d3.max(dataSpec, (d) => d.valueValue) as number;
+      if (attribute === 'negative') {
+        return [
+          { x: 0, y: high },
+          { x: 1, y: low },
+        ];
+      } else if (attribute === 'positive') {
+        return [
+          { x: 0, y: low },
+          { x: 1, y: high },
+        ];
+      } else if (attribute === 'invariable') {
+        // use average value
+        const avg = (high + low) / 2;
+        return [
+          { x: 0, y: avg },
+          { x: 1, y: avg },
+        ];
+      } else {
+        // actual
+        return dataSpec.map((d, i) => {
+          return {
+            x: i,
+            y: d.valueValue,
+            xLegend: d.categoryValue,
+          };
+        });
+      }
+    } else {
+      return dataSpec.map((d, i) => {
+        return {
+          x: i,
+          y: d.valueValue,
+          xLegend: d.categoryValue,
+        };
+      });
+    }
+  };
+
+  const dataset = transformData();
+
+  const lineVis = (
+    <LineChart
+      gistvisSpec={gistvisSpec}
+      visualizeData={dataset}
+      type={lineChartType}
+      colorScale={colorScale}
+      selectedEntity={currentEntity}
+      setSelectedEntity={setCurrentEntity}
+    />
+  );
+
+  return (
+    <span data-component-id={identifier}>
+      {vis.map((content, index) => {
+        if (content.displayType === 'text') {
+          return <span key={index}>{content.content}</span>;
+        } else if (content.displayType === 'entity') {
+          return (
+            <HoverText
+              key={index}
+              text={content.content}
+              isHovered={content.entity === currentEntity}
+              color={colorScale(content.entity ?? 'grey')}
+              onMouseOver={() => {
+                handleMouseEnter();
+                setCurrentEntity(content.entity ?? '');
+              }}
+              onMouseOut={() => {
+                handleMouseLeave();
+                setCurrentEntity('');
+              }}
+            />
+          );
+        } else if (content.displayType === 'word-scale-vis') {
+          return (
+            <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+              <span key={index}>
+                {content.content}
+                {lineVis}
+              </span>
+            </span>
+          );
+        }
+      })}
+    </span>
+  );
+};
+
+export default TrendTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/renderer/valueTextRenderer.tsx
+++ b/packages/gist-wsv/src/components/visualizer/renderer/valueTextRenderer.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { EntitySpec, GistvisSpec } from '../types';
+import * as d3 from 'd3';
+import HoverText from '../widgets/hoverText';
+import GlyphText from '../wordScaleVis/glyphText';
+import { getHighlightPos, getProductionVisSpec, getUniqueEntities } from '../utils/postProcess';
+import useTrackVisit from '../utils/useTrack';
+
+const ValueTextRenderer = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const id = gistvisSpec.id;
+  const { visitCount, handleMouseEnter, handleMouseLeave, identifier } = useTrackVisit('value-' + id);
+  const [currentEntity, setCurrentEntity] = useState<string>('');
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+
+  // const inSituPos: EntitySpec[] = getHighlightPos(gistvisSpec, "phrase");
+  const entityPos: EntitySpec[] = getHighlightPos(gistvisSpec, 'entity');
+  const uniqueEntities = getUniqueEntities(entityPos);
+
+  const vis = getProductionVisSpec(gistvisSpec.unitSegmentSpec.context, entityPos, 'right');
+
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(uniqueEntities);
+
+  const valueVis = (
+    <GlyphText
+      gistvisSpec={gistvisSpec}
+      colorScale={colorScale}
+      selectedEntity={currentEntity}
+      setSelectedEntity={setCurrentEntity}
+    />
+  );
+
+  return (
+    <span data-component-id={identifier}>
+      {vis.map((content, index) => {
+        if (content.displayType === 'text') {
+          return <span key={index}>{content.content}</span>;
+        } else if (content.displayType === 'entity') {
+          return (
+            <HoverText
+              key={index}
+              text={content.content}
+              isHovered={content.entity === currentEntity}
+              color={colorScale(content.entity ?? 'grey')}
+              onMouseOver={() => {
+                handleMouseEnter();
+                setCurrentEntity(content.entity ?? '');
+              }}
+              onMouseOut={() => {
+                handleMouseLeave();
+                setCurrentEntity('');
+              }}
+            />
+          );
+        } else if (content.displayType === 'word-scale-vis') {
+          return (
+            <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+              <span key={index}>
+                {content.content}
+                {valueVis}
+              </span>
+            </span>
+          );
+        }
+      })}
+    </span>
+  );
+};
+
+export default ValueTextRenderer;

--- a/packages/gist-wsv/src/components/visualizer/types.ts
+++ b/packages/gist-wsv/src/components/visualizer/types.ts
@@ -1,0 +1,74 @@
+// Intermediate representation for GistVis
+export type VisInsightType = 'comparison' | 'trend' | 'rank' | 'proportion' | 'extreme' | 'value';
+export type InsightType = VisInsightType | 'noType';
+
+export type ExtremeAttribute = 'maximum' | 'minimum';
+export type TrendAttribute = 'positive' | 'negative' | 'invariable';
+export type Attribute = ExtremeAttribute | TrendAttribute;
+
+export type DataSpec = {
+  categoryKey: string;
+  categoryValue: string;
+  valueKey: string;
+  valueValue: number;
+};
+
+export type UnitSegmentSpec = {
+  insightType: InsightType;
+  segmentIdx: number;
+  context: string;
+  attribute?: Attribute;
+  inSituPosition?: string[];
+};
+
+export interface GistvisSpec {
+  id: string;
+  unitSegmentSpec: UnitSegmentSpec;
+  dataSpec?: DataSpec[];
+}
+
+export type paragraphSpec = {
+  paragraphIdx: number;
+  paragraphContent: GistvisSpec[];
+};
+
+// Visualizer specifications
+export type TextPosition = {
+  start: number;
+  end: number;
+};
+
+export type EntitySpec = {
+  entity: string;
+  postion: TextPosition;
+};
+
+export type DisplayType = 'text' | 'entity' | 'word-scale-vis';
+export type DisplayPosition = 'left' | 'right' | 'none';
+
+export type DisplaySpec = {
+  displayType: DisplayType;
+  content: string;
+  entity?: string;
+  displayPosition?: DisplayPosition; // currently not supported
+};
+
+export interface ChartProps {
+  gistvisSpec: GistvisSpec;
+  colorScale: d3.ScaleOrdinal<string, string, never>;
+  selectedEntity: string;
+  setSelectedEntity: (entity: string) => void;
+}
+
+export type TrendOptions = 'actual' | 'nominal' | 'trending' | 'start-end';
+
+export interface LineChartProps extends ChartProps {
+  visualizeData: DataPoint[];
+  type: TrendOptions;
+}
+
+export interface DataPoint {
+  x: number;
+  xLegend?: string;
+  y: number;
+}

--- a/packages/gist-wsv/src/components/visualizer/utils/fuzzySearch.ts
+++ b/packages/gist-wsv/src/components/visualizer/utils/fuzzySearch.ts
@@ -1,0 +1,67 @@
+import Fuse from 'fuse.js';
+
+export const fuzzySearch = (queryString: string, context: string, isFuzzy: boolean = true) => {
+  // const context =
+  //   "The percentage of the sales of BYD is 30%, while the rest of the top 5 companies only consist of 25%. BYD";
+  // const queryString = "the rest of the top 5 companies";
+
+  if (!isFuzzy) {
+    // use direct match to find all matches, case insensitive
+
+    // Escape special characters in a string to safely insert it into a regular expression
+    const escapeRegExp = (text: string) => {
+      return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    };
+
+    const escapedQuery = escapeRegExp(queryString);
+    // Determine if word boundaries should be applied based on the first and last character
+    const startBoundary = /^\w/.test(queryString) ? '\\b' : '';
+    const endBoundary = /\w$/.test(queryString) ? '\\b' : '';
+    const regex = new RegExp(`${startBoundary}${escapedQuery}${endBoundary}`, 'gi');
+
+    const matches = Array.from(context.matchAll(regex), (match) => {
+      const startIndex = match.index;
+      const endIndex = startIndex + match[0].length;
+      return [startIndex, endIndex];
+    });
+    return matches;
+  }
+
+  const options = {
+    shouldSort: true,
+    includeMatches: true,
+    includeScore: true,
+    threshold: 0.6,
+    findAllMatches: true,
+    ignoreLocation: true,
+    keys: ['text'],
+    // tokenize: true,
+    // tokenSeparator: /[\s.,;:!?]+/
+  };
+
+  const fuse = new Fuse([{ text: context }], options);
+  const result = fuse.search(queryString);
+
+  const proposalIndicesList = result.flatMap(
+    (item) => item.matches?.map((match) => match.indices.map((index) => [index[0], index[1]])) || []
+  );
+
+  if (proposalIndicesList.length === 0) {
+    return [];
+  } else {
+    const queryStringLength = queryString.length;
+    // use the best match
+    const proposedMatchLength = proposalIndicesList[0].map((item) => item[1] - item[0]);
+    const proposedMatchDiff = proposedMatchLength.map((item) => Math.abs(item - queryStringLength));
+    // console.log(proposedMatchDiff);
+    // find a diff that is the closest to 0, if equal, return both, get the indices
+    const minDiff = Math.min(...proposedMatchDiff);
+    const bestMatchIndices = proposedMatchDiff.reduce((acc, curr, index) => {
+      if (curr === minDiff) {
+        acc.push(proposalIndicesList[0][index]);
+      }
+      return acc;
+    }, [] as number[][]);
+    return bestMatchIndices;
+  }
+};

--- a/packages/gist-wsv/src/components/visualizer/utils/postProcess.ts
+++ b/packages/gist-wsv/src/components/visualizer/utils/postProcess.ts
@@ -1,0 +1,105 @@
+import { DataSpec, DisplayPosition, DisplaySpec, EntitySpec, GistvisSpec } from '../types';
+import { fuzzySearch } from './fuzzySearch';
+import lodash from 'lodash';
+
+export const getHighlightPos = (gistVisSpec: GistvisSpec, type: 'phrase' | 'entity'): EntitySpec[] => {
+  let items: string[] | DataSpec[] = [];
+
+  if (type === 'phrase') {
+    items = gistVisSpec.unitSegmentSpec.inSituPosition ?? [];
+  } else if (type === 'entity') {
+    items = gistVisSpec.dataSpec ?? [];
+  }
+
+  return items
+    .map((item: string | DataSpec) => {
+      const str = typeof item === 'string' ? item : item.categoryValue;
+      const pos = fuzzySearch(str, gistVisSpec.unitSegmentSpec.context, false);
+      const posArray = pos.map((p) => {
+        return {
+          entity: str,
+          postion: {
+            start: p[0],
+            end: p[1],
+          },
+        } as EntitySpec;
+      });
+      return posArray;
+    })
+    .flat();
+};
+
+export const getUniqueEntities = (entityPos: EntitySpec[]) => {
+  return lodash.uniqBy(
+    entityPos.map((d) => d.entity),
+    'entity'
+  );
+};
+
+export const getNonOverlappingEntities = (entityPos: EntitySpec[]) => {
+  // Sort entityPos by start position using lodash
+  const sortedEntityPos = lodash.sortBy(entityPos, ['postion.start']);
+  // Filter out overlapping entities using reduce
+  const nonOverlappingEntities = sortedEntityPos.reduce((acc: EntitySpec[], entity: EntitySpec) => {
+    if (acc.length === 0 || entity.postion.start >= acc[acc.length - 1].postion.end) {
+      return [...acc, entity];
+    }
+    return acc;
+  }, []);
+  return nonOverlappingEntities;
+};
+
+export const getProductionVisSpec = (text: string, entityPos: EntitySpec[], displayPos: DisplayPosition = 'none') => {
+  const nonOverlappingEntities = getNonOverlappingEntities(entityPos);
+
+  const contentArray: DisplaySpec[] = [];
+  let lastEnd = 0;
+  nonOverlappingEntities.forEach((entity) => {
+    if (entity.postion.start > lastEnd) {
+      contentArray.push({
+        displayType: 'text',
+        content: text.slice(lastEnd, entity.postion.start),
+      });
+    }
+    if (displayPos === 'left') {
+      contentArray.push({
+        displayType: 'word-scale-vis',
+        content: ' ',
+      });
+    }
+    contentArray.push({
+      displayType: 'entity',
+      content: text.slice(entity.postion.start, entity.postion.end),
+      entity: entity.entity,
+    });
+    if (displayPos === 'right') {
+      contentArray.push({
+        displayType: 'word-scale-vis',
+        content: ' ',
+      });
+    }
+    lastEnd = entity.postion.end;
+  });
+
+  if (lastEnd < text.length) {
+    // check if the trimmed last character is a punctuaation
+    const lastChar = text.slice(text.length - 1);
+    const isPunctuation = /[.,;!?]/.test(lastChar);
+    const endPos = isPunctuation ? text.length - 1 : text.length;
+    contentArray.push({
+      displayType: 'text',
+      content: text.slice(lastEnd, endPos),
+    });
+    if (displayPos === 'none') {
+      contentArray.push({
+        displayType: 'word-scale-vis',
+        content: ' ',
+      });
+    }
+    contentArray.push({
+      displayType: 'text',
+      content: text.slice(endPos) + ' ',
+    });
+  }
+  return contentArray;
+};

--- a/packages/gist-wsv/src/components/visualizer/utils/useTrack.ts
+++ b/packages/gist-wsv/src/components/visualizer/utils/useTrack.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAtom } from 'jotai';
+// import { articleIdAtom } from '../../../globalState';
+const generateUniqueIdentifier = () => Math.random().toString(36).substr(2, 9);
+const useTrackVisit = (id: string) => {
+  // const [articleId] = useAtom(articleIdAtom);
+  const [visitCount, setVisitCount] = useState(0);
+  const stayStartTimeRef = useRef<number | null>(null);
+  const [identifier, setID] = useState(id);
+  const handleMouseEnter = () => {
+    if (stayStartTimeRef.current === null) {
+      setVisitCount((prevCount) => prevCount + 1);
+      stayStartTimeRef.current = Date.now();
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (stayStartTimeRef.current !== null) {
+      const stayTime = Date.now() - stayStartTimeRef.current;
+      const data = {
+        identifier: identifier,
+        visitCount: visitCount,
+        stayTime: stayTime,
+        // articleId: articleId,
+      };
+
+      fetch('http://localhost:5000/api/trackVisit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          console.log('Success:', data);
+        })
+        .catch((error) => {
+          console.error('Error:', error);
+        });
+
+      stayStartTimeRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (stayStartTimeRef.current !== null) {
+        console.log('Component unmounted while hovering');
+      }
+    };
+  }, []);
+
+  return {
+    visitCount,
+    handleMouseEnter,
+    handleMouseLeave,
+    identifier,
+  };
+};
+
+export default useTrackVisit;

--- a/packages/gist-wsv/src/components/visualizer/utils/useTrack.ts
+++ b/packages/gist-wsv/src/components/visualizer/utils/useTrack.ts
@@ -8,46 +8,13 @@ const useTrackVisit = (id: string) => {
   const stayStartTimeRef = useRef<number | null>(null);
   const [identifier, setID] = useState(id);
   const handleMouseEnter = () => {
-    if (stayStartTimeRef.current === null) {
-      setVisitCount((prevCount) => prevCount + 1);
-      stayStartTimeRef.current = Date.now();
-    }
   };
 
   const handleMouseLeave = () => {
-    if (stayStartTimeRef.current !== null) {
-      const stayTime = Date.now() - stayStartTimeRef.current;
-      const data = {
-        identifier: identifier,
-        visitCount: visitCount,
-        stayTime: stayTime,
-        // articleId: articleId,
-      };
-
-      fetch('http://localhost:5000/api/trackVisit', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          console.log('Success:', data);
-        })
-        .catch((error) => {
-          console.error('Error:', error);
-        });
-
-      stayStartTimeRef.current = null;
-    }
   };
 
   useEffect(() => {
     return () => {
-      if (stayStartTimeRef.current !== null) {
-        console.log('Component unmounted while hovering');
-      }
     };
   }, []);
 

--- a/packages/gist-wsv/src/components/visualizer/utils/useTrack.ts
+++ b/packages/gist-wsv/src/components/visualizer/utils/useTrack.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { useAtom } from 'jotai';
 // import { articleIdAtom } from '../../../globalState';
 const generateUniqueIdentifier = () => Math.random().toString(36).substr(2, 9);
 const useTrackVisit = (id: string) => {

--- a/packages/gist-wsv/src/components/visualizer/utils/utils.ts
+++ b/packages/gist-wsv/src/components/visualizer/utils/utils.ts
@@ -1,0 +1,84 @@
+import { gistKB } from '../../llm/visKB';
+import { GistvisSpec, InsightType, DataSpec } from '../types';
+
+export const capitalizeFirstLetter = (str: string) => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+export const recommendValidTypes = (gistVisSpec: GistvisSpec) => {
+  const dataSpec = gistVisSpec.dataSpec ?? [];
+  const unitSegmentSpec = gistVisSpec.unitSegmentSpec;
+  // No dataSpec, revert to noType;
+  // More than 10 entries, too long for word-scale vis, revert to noType
+  if (dataSpec.length === 0 || dataSpec.length > 10) {
+    return ['noType'] as InsightType[];
+  }
+
+  const dataSpecLength = dataSpec.length;
+
+  // Task 1: check valueValue isNaN
+  const valueValueHasNaN = dataSpec.some((d) => isNaN(d.valueValue));
+  const categoryValueHasEmpty = dataSpec.some((d) => d.categoryValue === '');
+
+  // Task 2: check insituPos
+  const inSituPositionList: string[] = unitSegmentSpec.inSituPosition ?? [];
+  const hasGotInsituPos = inSituPositionList.length > 0;
+
+  // Task 3: check attribute string
+  const attribute = unitSegmentSpec.attribute ?? '';
+  const validForNominalTrend = attribute === 'negative' || attribute === 'positive' || attribute === 'invariable';
+  const validForExtreme = attribute === 'maximum' || attribute === 'minimum';
+
+  // Task 4: valueValue attribute
+  const sumOfValueValue = dataSpec.reduce((sum, d) => sum + d.valueValue, 0);
+  const isInOneToTenRange = dataSpec.every((d) => d.valueValue >= 1 && d.valueValue <= 10);
+
+  const notValidTypes: InsightType[] = [];
+  if (valueValueHasNaN || categoryValueHasEmpty || dataSpecLength < 2) {
+    notValidTypes.push('comparison');
+  }
+  // value/extreme must have inSitu position
+  if (!hasGotInsituPos) {
+    notValidTypes.push('value');
+    notValidTypes.push('extreme');
+  }
+  if (valueValueHasNaN || categoryValueHasEmpty) {
+    notValidTypes.push('value');
+  }
+  // extreme must have attribute
+  if (!validForExtreme || inSituPositionList.length > 1) {
+    notValidTypes.push('extreme');
+  }
+
+  const checkInvariableTrend = (dataSpec: DataSpec[]): boolean => {
+    if (dataSpec.length < 2) return false;
+    const variations = dataSpec.slice(1).map((curr, idx) => {
+      const prev = dataSpec[idx].valueValue;
+      const change = Math.abs(curr.valueValue - prev) / prev;
+      return change;
+    });
+    const VARIATION_THRESHOLD = 0.10; 
+    return variations.every(v => v <= VARIATION_THRESHOLD);
+  };
+  
+  // not negative/positive, while there exist empty value, or less than 2 data points, not valid for trend
+  if (!validForNominalTrend && (valueValueHasNaN || dataSpecLength < 2)) {
+    notValidTypes.push('trend');
+  }else if (attribute === 'invariable' && !checkInvariableTrend(dataSpec)) {
+    notValidTypes.push('trend');
+  }
+  // if the sum of valueValue is greater than 1, than not a proportion
+  if (valueValueHasNaN || categoryValueHasEmpty || sumOfValueValue > 1) {
+    notValidTypes.push('proportion');
+  }
+  // if valueValue is not in 1-10 range, should not be a rank
+  if (!isInOneToTenRange || valueValueHasNaN || categoryValueHasEmpty) {
+    notValidTypes.push('rank');
+  }
+
+  const validTypes = Object.keys(gistKB).filter((type) => !notValidTypes.includes(type as InsightType));
+  // noType is always welcome
+  validTypes.push('noType');
+
+  return validTypes as InsightType[];
+};

--- a/packages/gist-wsv/src/components/visualizer/widgets/fallbackVis.tsx
+++ b/packages/gist-wsv/src/components/visualizer/widgets/fallbackVis.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Tooltip } from 'antd';
+import { QuestionCircleOutlined } from '@ant-design/icons';
+import { GistvisSpec } from '../types';
+
+const FallBackCase = ({ gistvisSpec }: { gistvisSpec: GistvisSpec }) => {
+  const insightType = gistvisSpec.unitSegmentSpec.insightType;
+
+  const toolTipContent = (
+    <div
+      style={{
+        lineHeight: 1.1,
+        fontSize: '14px',
+        color: 'black',
+        fontWeight: 'bold',
+      }}
+    >
+      May contain data insight of {insightType}.
+    </div>
+  );
+  const endingPunctuation = gistvisSpec.unitSegmentSpec.context[gistvisSpec.unitSegmentSpec.context.length - 1] + ' ';
+
+  const [isSelected, setIsSelected] = useState(false);
+  const hoverStyle = {
+    opacity: isSelected ? 1 : 0.5,
+    transition: 'opacity 0.3s',
+  };
+  return (
+    <span>
+      {gistvisSpec.unitSegmentSpec.context.slice(0, -1)}{' '}
+      <Tooltip title={toolTipContent} placement="bottom" color="#ffffff">
+        <QuestionCircleOutlined
+          style={hoverStyle}
+          onMouseOver={() => setIsSelected(true)}
+          onMouseLeave={() => setIsSelected(false)}
+        />
+      </Tooltip>
+      {endingPunctuation}
+    </span>
+  );
+};
+
+export default FallBackCase;

--- a/packages/gist-wsv/src/components/visualizer/widgets/hoverText.tsx
+++ b/packages/gist-wsv/src/components/visualizer/widgets/hoverText.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const styles = {
+  text: {
+    transition: 'color 0.3s, border 0.3s, transform 0.3s, box-shadow 0.3s, font-weight 0.3s',
+    border: '2px solid transparent',
+    borderRadius: '8px',
+    // display: 'inline-block',
+  },
+  hoveredText: {
+    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
+  },
+};
+
+interface HoverTextProps {
+  text: string;
+  isHovered: boolean;
+  color: string;
+  onMouseOver: () => void;
+  onMouseOut: () => void;
+}
+
+const HoverText = ({ text, isHovered, color, onMouseOver, onMouseOut }: HoverTextProps) => {
+  return (
+    <span
+      style={{
+        ...styles.text,
+        ...(isHovered ? styles.hoveredText : {}),
+        color: color,
+        backgroundColor: isHovered ? `${color}19` : 'transparent',
+      }}
+      onMouseOver={onMouseOver}
+      onMouseOut={onMouseOut}
+    >
+      {text}
+    </span>
+  );
+};
+
+export default HoverText;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/chartList.ts
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/chartList.ts
@@ -1,0 +1,5 @@
+export { default as HorizontalStackedBarChart } from './hStackedBarChart';
+export { default as LineChart } from './lineChart';
+export { default as VerticalBarChart } from './vBarChart';
+export { default as GlyphMaxMin } from './glyphMaxMin';
+export { default as GlyphText } from './glyphText';

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/glyphMaxMin.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/glyphMaxMin.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import * as d3 from 'd3';
+import { SVG_WIDTH, SVG_HEIGHT, SVG_UNIT_WIDTH } from '../constants';
+import { ChartProps, ExtremeAttribute } from '../types';
+import { Tooltip } from 'antd';
+
+const GlyphsMaxMin = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }: ChartProps) => {
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+  const attribute = gistvisSpec.unitSegmentSpec.attribute as ExtremeAttribute;
+  const highlightEntity = gistvisSpec.unitSegmentSpec.inSituPosition ?? [];
+
+  const xScale = d3.scaleLinear().domain([0, 1]).range([0, SVG_WIDTH]);
+
+  const glyphColor = attribute === 'maximum' ? '#E6450F' : 'green';
+  const mainElement = highlightEntity.slice(0, 1).map((d: string, i: number) => {
+    const hoverStyle = {
+      opacity: d === selectedEntity ? 1 : 0.5,
+      transition: 'opacity 0.3s',
+    };
+    const triangles = {
+      maximum: [
+        [0, SVG_HEIGHT],
+        [SVG_UNIT_WIDTH, SVG_HEIGHT],
+        [SVG_UNIT_WIDTH / 2, SVG_HEIGHT - (Math.sqrt(3) * SVG_UNIT_WIDTH) / 2],
+      ],
+      minimum: [
+        [0, SVG_HEIGHT - (Math.sqrt(3) * SVG_UNIT_WIDTH) / 2],
+        [SVG_UNIT_WIDTH, SVG_HEIGHT - (Math.sqrt(3) * SVG_UNIT_WIDTH) / 2],
+        [SVG_UNIT_WIDTH / 2, SVG_HEIGHT],
+      ],
+    };
+
+    const pointsStringify = triangles[attribute].map((d) => d.join(',')).join(' ');
+    return (
+      <polygon
+        key={d}
+        points={pointsStringify}
+        fill={glyphColor}
+        style={hoverStyle}
+        onMouseOver={() => setSelectedEntity(d)}
+        onMouseOut={() => setSelectedEntity('')}
+      />
+    );
+  });
+
+  const toolTipContent = (
+    <div
+      style={{
+        lineHeight: 1.1,
+        fontSize: '14px',
+        color: `${glyphColor}`,
+        fontWeight: 'bold',
+      }}
+    >
+      {dataSpec.length > 0 ? 'The ' + attribute + ' of ' + dataSpec[0].categoryKey : attribute}
+    </div>
+  );
+
+  const visElement = (
+    <Tooltip title={toolTipContent} placement="bottom" color="#ffffff">
+      <svg height={SVG_HEIGHT} width={SVG_UNIT_WIDTH}>
+        {mainElement}
+      </svg>
+    </Tooltip>
+  );
+
+  return <>{visElement}</>;
+};
+
+export default GlyphsMaxMin;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/glyphText.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/glyphText.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import * as d3 from 'd3';
+import { SVG_HEIGHT, SVG_PADDING } from '../constants';
+import { ChartProps, DataSpec } from '../types';
+import { Tooltip } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+
+const GlyphText = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }: ChartProps) => {
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+  // process cases with one value only
+  const value = dataSpec.map((d: DataSpec) => d.valueValue)[0];
+  const inSituPosition = gistvisSpec.unitSegmentSpec.inSituPosition ?? [];
+
+  const targetEntity = dataSpec.map((d: DataSpec) => d.categoryValue)[0];
+
+  const getToolTipContent = (value: number, category: string) => {
+    const formatter = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    return (
+      <div
+        style={{
+          lineHeight: 1.1,
+          fontSize: '14px',
+          color: colorScale(category),
+          fontWeight: 'bold',
+        }}
+      >
+        The value of {category} is {formatter.format(value)}
+      </div>
+    );
+  };
+
+  const getVisElement = (value: number, currentEntity: string) => {
+    const hoverStyle = {
+      opacity: currentEntity === selectedEntity ? 1 : 0.5,
+      transition: 'opacity 0.3s',
+    };
+    // if value < 0, then return the value
+    if (value > 0 && value <= 100) {
+      const glyphElementWidth = 6;
+      const numRows = 5;
+      const pointsPerRow = Math.ceil(value / numRows);
+
+      const xScale = d3
+        .scaleLinear()
+        .domain([0, pointsPerRow])
+        .range([SVG_PADDING, glyphElementWidth * pointsPerRow - SVG_PADDING]);
+
+      const yScale = d3
+        .scaleLinear()
+        .domain([0, numRows])
+        .range([SVG_HEIGHT - SVG_PADDING, SVG_PADDING]);
+
+      const points = Array.from({ length: value }, (_, i) => {
+        return {
+          x: xScale(i % pointsPerRow),
+          y: yScale(Math.floor(i / pointsPerRow)),
+        };
+      });
+
+      return (
+        <svg
+          width={glyphElementWidth * pointsPerRow}
+          height={SVG_HEIGHT}
+          style={hoverStyle}
+          onMouseOver={() => setSelectedEntity(currentEntity)}
+          onMouseOut={() => setSelectedEntity('')}
+        >
+          {points.map((point, index) => (
+            <circle key={index} cx={point.x} cy={point.y} r={1.2} fill={colorScale(currentEntity)} />
+          ))}
+        </svg>
+      );
+    } else {
+      return (
+        <SearchOutlined
+          style={{ ...hoverStyle, color: colorScale(currentEntity) }}
+          onMouseOver={() => setSelectedEntity(currentEntity)}
+          onMouseOut={() => setSelectedEntity('')}
+        />
+      );
+    }
+  };
+
+  const mainElement = dataSpec.map((d: DataSpec, i: number) => {
+    const hoverStyle = {
+      opacity: d.categoryValue === selectedEntity ? 1 : 0.5,
+      transition: 'opacity 0.3s',
+    };
+    return (
+      <Tooltip title={getToolTipContent(d.valueValue, d.categoryValue)} placement="bottom" color="#ffffff">
+        {getVisElement(d.valueValue, d.categoryValue)}
+      </Tooltip>
+    );
+  });
+
+  // const mainElement = highlightEntity
+  //   .map((d: string, i: number) => {
+  //     const hoverStyle = {
+  //       opacity: d === selectedEntity ? 1 : 0.5,
+  //       transition: "opacity 0.3s",
+  //     };
+  //     return (
+  //       <span>{d}</span>
+  //     );
+  //   });
+
+  return <>{mainElement}</>;
+};
+
+export default GlyphText;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/hStackedBarChart.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/hStackedBarChart.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import * as d3 from 'd3';
+import { SVG_WIDTH, SVG_HEIGHT } from '../constants';
+import { ChartProps, DataSpec } from '../types';
+import { Tooltip } from 'antd';
+
+const HorizontalStackedBar = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }: ChartProps) => {
+  const dataSpec = gistvisSpec?.dataSpec ?? [];
+  const xScale = d3.scaleLinear().domain([0, 1]).range([0, SVG_WIDTH]);
+  let curSum = 0;
+  const knownCategories = dataSpec.map((d: DataSpec, i: number) => {
+    const thisPos = xScale(curSum);
+    curSum += d.valueValue;
+    const hoverStyle = {
+      opacity: d.categoryValue === selectedEntity ? 1 : 0.5,
+      transition: 'opacity 0.3s',
+    };
+    return (
+      <rect
+        key={d.categoryValue}
+        x={thisPos}
+        y={SVG_HEIGHT * 0.2}
+        width={xScale(d.valueValue)}
+        height={SVG_HEIGHT * 0.8}
+        fill={colorScale(d.categoryValue)}
+        style={hoverStyle}
+        // onClick={() => setCurrentEntity(d.categoryValue)}
+        onMouseOver={() => {
+          setSelectedEntity(d.categoryValue);
+        }}
+        onMouseOut={() => {
+          setSelectedEntity('');
+        }}
+      />
+    );
+  });
+
+  const unknownCategories = (
+    <rect
+      x={xScale(curSum)}
+      y={SVG_HEIGHT * 0.2}
+      width={SVG_WIDTH - xScale(curSum)}
+      height={SVG_HEIGHT * 0.8}
+      style={{ opacity: 0.5 }}
+      fill={colorScale('')}
+      // onClick={() => setCurrentEntity("unknown")}
+    />
+  );
+
+  const toolTipContent = (
+    <div
+      style={{
+        lineHeight: 1.1,
+        fontSize: '14px',
+        fontWeight: 'bold',
+        color: '#000000',
+      }}
+    >
+      The proportion of{' '}
+      <span style={{ color: colorScale(selectedEntity) }}>{selectedEntity === '' ? 'others' : selectedEntity}</span> is{' '}
+      <span style={{ color: colorScale(selectedEntity) }}>
+        {dataSpec.find((d: DataSpec) => d.categoryValue === selectedEntity)?.valueValue !== undefined
+          ? dataSpec.find((d: DataSpec) => d.categoryValue === selectedEntity)?.valueValue?.toFixed(2)
+          : (1 - curSum).toFixed(2)}
+      </span>
+    </div>
+  );
+
+  const visElement = (
+    <Tooltip title={toolTipContent} placement="bottom" color="#ffffff">
+      <svg height={SVG_HEIGHT} width={SVG_WIDTH}>
+        {knownCategories && [...knownCategories, unknownCategories]}
+      </svg>
+    </Tooltip>
+  );
+
+  return <>{visElement}</>;
+};
+
+export default HorizontalStackedBar;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleBar.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleBar.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { SimpleBarChartProps } from './types';
+import VerticalBarChart from '../vBarChart';
+import { GistvisSpec } from '../../types';
+import * as d3 from 'd3';
+
+const SimpleBar: React.FC<SimpleBarChartProps> = ({
+  data,
+  color = '#1890ff',
+  colors,
+  type = 'comparison',
+  width,
+  height,
+}) => {
+  // construct GistvisSpec
+  const gistvisSpec: GistvisSpec = {
+    id: Math.random().toString(36).substr(2, 9),
+    unitSegmentSpec: {
+      insightType: type === 'rank' ? 'rank' : 'comparison',
+      segmentIdx: 0,
+      context: '',
+    },
+    dataSpec: data.map((point, index) => ({
+      categoryKey: 'category',
+      categoryValue: point.label || `Item ${index + 1}`,
+      valueKey: 'value',
+      valueValue: point.y,
+    })),
+  };
+
+  // construct color scale
+  const colorScale = d3.scaleOrdinal<string>();
+  
+  if (colors) {
+    // if provided colors
+    colorScale.range(colors);
+  } else {
+    colorScale.range(data.map(() => color));
+  }
+
+  const [selectedEntity, setSelectedEntity] = React.useState('');
+
+  return (
+    <VerticalBarChart
+      gistvisSpec={gistvisSpec}
+      colorScale={colorScale}
+      selectedEntity={selectedEntity}
+      setSelectedEntity={setSelectedEntity}
+    />
+  );
+};
+
+export default SimpleBar;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleLine.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleLine.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { SimpleLineChartProps } from './types';
+import Line from '../lineChart';
+import { GistvisSpec, DataPoint } from '../../types';
+import * as d3 from 'd3';
+import { SVG_HEIGHT } from '../../constants';
+
+const SimpleLine: React.FC<SimpleLineChartProps> = ({
+  data,
+  type = 'actual',
+  attribute = 'invariable',
+  color = '#1890ff',
+  width,
+  height = SVG_HEIGHT,
+}) => {
+  // construct GistvisSpec
+  const gistvisSpec: GistvisSpec = {
+    id: Math.random().toString(36).substr(2, 9),
+    unitSegmentSpec: {
+      insightType: 'trend',
+      segmentIdx: 0,
+      context: '',
+      attribute: attribute,
+    },
+    dataSpec: data.map((point, index) => ({
+      categoryKey: 'time',
+      categoryValue: point.label || index.toString(),
+      valueKey: 'value',
+      valueValue: point.y,
+    })),
+  };
+
+  // construct color scale
+  const colorScale = d3.scaleOrdinal<string>().range([color]);
+
+  return (
+    <Line
+      gistvisSpec={gistvisSpec}
+      visualizeData={data}
+      type={type}
+      colorScale={colorScale}
+      selectedEntity=""
+      setSelectedEntity={() => {}}
+    />
+  );
+};
+
+export default SimpleLine;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleMaxMin.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleMaxMin.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { SimpleMaxMinProps } from './types';
+import GlyphsMaxMin from '../glyphMaxMin';
+import { GistvisSpec } from '../../types';
+import * as d3 from 'd3';
+import { SVG_HEIGHT } from '../../constants';
+
+const SimpleMaxMin: React.FC<SimpleMaxMinProps> = ({
+  min,
+  max,
+  current,
+  color,
+  width,
+  height = SVG_HEIGHT,
+}) => {
+  // judge if current is closer to max or min
+  const isMax = Math.abs(current - max) < Math.abs(current - min);
+  const attribute = isMax ? 'maximum' : 'minimum';
+
+  // construct GistvisSpec
+  const gistvisSpec: GistvisSpec = {
+    id: Math.random().toString(36).substr(2, 9),
+    unitSegmentSpec: {
+      insightType: 'extreme',
+      segmentIdx: 0,
+      context: '',
+      attribute: attribute,
+      inSituPosition: ['current'],
+    },
+    dataSpec: [{
+      categoryKey: 'value',
+      categoryValue: 'current',
+      valueKey: `${attribute} value`,
+      valueValue: current,
+    }],
+  };
+
+  // construct color scale
+  const colorScale = d3.scaleOrdinal<string>().range([
+    color || (attribute === 'maximum' ? '#E6450F' : 'green')
+  ]);
+
+  const [selectedEntity, setSelectedEntity] = React.useState('');
+
+  return (
+    <GlyphsMaxMin
+      gistvisSpec={gistvisSpec}
+      colorScale={colorScale}
+      selectedEntity={selectedEntity}
+      setSelectedEntity={setSelectedEntity}
+    />
+  );
+};
+
+export default SimpleMaxMin;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleStackedBar.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/SimpleStackedBar.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { SimpleStackedBarChartProps } from './types';
+import HorizontalStackedBar from '../hStackedBarChart';
+import { GistvisSpec } from '../../types';
+import * as d3 from 'd3';
+import { SVG_HEIGHT } from '../../constants';
+
+const SimpleStackedBar: React.FC<SimpleStackedBarChartProps> = ({
+  data,
+  colors = ['#1890ff', '#13c2c2', '#52c41a', '#faad14', '#f5222d'],
+  width,
+  height = SVG_HEIGHT,
+}) => {
+  // turn values into proportions
+  const total = data.reduce((sum, item) => sum + item.values.reduce((a, b) => a + b, 0), 0);
+  const normalizedData = data.map(item => ({
+    category: item.category,
+    values: item.values.map(v => v / total)
+  }));
+
+  // construct GistvisSpec
+  const gistvisSpec: GistvisSpec = {
+    id: Math.random().toString(36).substr(2, 9),
+    unitSegmentSpec: {
+      insightType: 'proportion',
+      segmentIdx: 0,
+      context: '',
+    },
+    dataSpec: normalizedData.flatMap((item, i) => 
+      item.values.map(value => ({
+        categoryKey: 'category',
+        categoryValue: item.category,
+        valueKey: 'proportion',
+        valueValue: value,
+      }))
+    ),
+  };
+
+  // construct color scale
+  const colorScale = d3.scaleOrdinal<string>()
+    .domain(data.map(d => d.category))
+    .range(colors);
+
+  const [selectedEntity, setSelectedEntity] = React.useState('');
+
+  return (
+    <HorizontalStackedBar
+      gistvisSpec={gistvisSpec}
+      colorScale={colorScale}
+      selectedEntity={selectedEntity}
+      setSelectedEntity={setSelectedEntity}
+    />
+  );
+};
+
+export default SimpleStackedBar;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/index.ts
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/index.ts
@@ -1,0 +1,15 @@
+export { default as SimpleLine } from './SimpleLine';
+export { default as SimpleBar } from './SimpleBar';
+export { default as SimpleStackedBar } from './SimpleStackedBar';
+export { default as SimpleMaxMin } from './SimpleMaxMin';
+
+export type { 
+  SimpleLineChartProps,
+  SimpleBarChartProps,
+  SimpleStackedBarChartProps,
+  SimpleMaxMinProps,
+  DataPoint,
+  TrendType,
+  TrendAttribute,
+  BarType
+} from './types';

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/types.ts
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/types.ts
@@ -1,0 +1,46 @@
+export type TrendType = 'actual' | 'nominal' | 'trending' | 'start-end';
+export type TrendAttribute = 'positive' | 'negative' | 'invariable';
+export type BarType = 'comparison' | 'rank';
+
+export interface DataPoint {
+  x: number;
+  y: number;
+  label?: string;
+}
+
+export interface SimpleLineChartProps {
+  data: DataPoint[];
+  type?: TrendType;
+  attribute?: TrendAttribute;
+  color?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface SimpleBarChartProps {
+  data: DataPoint[];
+  type?: BarType;
+  color?: string;
+  colors?: string[];
+  width?: number;
+  height?: number;
+}
+
+export interface SimpleStackedBarChartProps {
+  data: {
+    category: string;
+    values: number[];
+  }[];
+  colors?: string[];
+  width?: number;
+  height?: number;
+}
+
+export interface SimpleMaxMinProps {
+  min: number;
+  max: number;
+  current: number;
+  color?: string;
+  width?: number;
+  height?: number;
+}

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/lineChart.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/lineChart.tsx
@@ -1,0 +1,252 @@
+import React, { useState } from 'react';
+import * as d3 from 'd3';
+import { SVG_HEIGHT, SVG_PADDING, SVG_UNIT_WIDTH, SVG_INTERVAL } from '../constants';
+import { DataPoint, LineChartProps } from '../types';
+import { Tooltip } from 'antd';
+import { capitalizeFirstLetter } from '../utils/utils';
+
+interface LineChartTooltipProps {
+  x: number;
+  y: number;
+  value: number;
+}
+
+const Line = ({ gistvisSpec, visualizeData, type, colorScale, selectedEntity, setSelectedEntity }: LineChartProps) => {
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+  const dataset = visualizeData;
+
+  const svgRef = React.useRef<SVGSVGElement>(null);
+  const lineChartWidth = type === 'start-end' ? SVG_UNIT_WIDTH * dataset.length * 2 : SVG_UNIT_WIDTH * dataset.length;
+  const lineChartHeight = SVG_HEIGHT;
+
+  const dataPosX = dataset[dataset.length - 1].x;
+  const differenceLineDataset: DataPoint[] = [
+    { x: dataPosX, y: dataset[0].y },
+    { x: dataPosX, y: dataset[dataset.length - 1].y },
+  ];
+
+  const xScale = d3
+    .scaleLinear()
+    .domain(d3.extent(dataset, (d) => d.x) as [number, number])
+    .range([SVG_PADDING, lineChartWidth - SVG_PADDING]);
+
+  const yScale = d3
+    .scaleLinear()
+    .domain(d3.extent(dataset, (d) => d.y) as [number, number])
+    .range([lineChartHeight - SVG_PADDING, SVG_PADDING]);
+
+  const lineGenerator = d3
+    .line<{ x: number; y: number }>()
+    .x((d) => xScale(d.x))
+    .y((d) => yScale(d.y))
+    .curve(gistvisSpec.unitSegmentSpec.attribute === 'invariable' 
+      ? d3.curveMonotoneX 
+      : d3.curveLinear); 
+
+  const lineGeneratorDifference = d3
+    .line<{ x: number; y: number }>()
+    .x((d) => xScale(d.x) + SVG_INTERVAL)
+    .y((d) => yScale(d.y));
+
+  const areaGenerator = d3
+    .area<{ x: number; y: number }>()
+    .x((d) => xScale(d.x))
+    .y1((d) => yScale(d.y))
+    .y0(yScale(0));
+
+  const getTooltipContnet = (selectionVal: number | null) => {
+    if (type === 'nominal') {
+      return (
+        <div
+          style={{
+            lineHeight: 1.1,
+            fontSize: '14px',
+            color: `${lineColor}`,
+            fontWeight: 'bold',
+          }}
+        >
+          {gistvisSpec.unitSegmentSpec.attribute === 'positive' 
+          ? '↗ increasing' 
+          : gistvisSpec.unitSegmentSpec.attribute === 'negative'
+            ? '↘ decreasing'
+            : '→ stable'}
+        </div>
+      );
+    } else if (type === 'trending') {
+      return (
+        <div
+          style={{
+            lineHeight: 1.1,
+            fontSize: '14px',
+            color: `${lineColor}`,
+            fontWeight: 'bold',
+          }}
+        >
+          {gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increased' : '↘ decreased'}{' '}
+          {dataSpec[0].valueValue}
+        </div>
+      );
+    } else if (type === 'start-end') {
+      return (
+        <div
+          style={{
+            lineHeight: 1.1,
+            fontSize: '14px',
+            color: `${lineColor}`,
+            fontWeight: 'bold',
+          }}
+        >
+          {capitalizeFirstLetter(dataSpec[0].valueKey) +
+            ' of ' +
+            dataSpec.find((d) => d.valueValue === selectionVal)?.categoryValue +
+            ': ' +
+            selectionVal}
+          {gistvisSpec.unitSegmentSpec.attribute === 'invariable' 
+            ? '. The value remains stable.'
+            : `. The ${gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increase' : '↘ decrease'} is ${
+                Math.abs(dataSpec[1].valueValue - dataSpec[0].valueValue)
+              }.`}
+        </div>
+      );
+    } else {
+      return (
+        <div
+          style={{
+            lineHeight: 1.1,
+            fontSize: '14px',
+            color: `${lineColor}`,
+            fontWeight: 'bold',
+          }}
+        >
+          {capitalizeFirstLetter(dataSpec[0].valueKey) +
+            ' of ' +
+            dataSpec.find((d) => d.valueValue === selectionVal)?.categoryValue +
+            ': ' +
+            selectionVal}
+          .
+        </div>
+      );
+    }
+  };
+
+  const [tooltip, setTooltip] = useState<LineChartTooltipProps | null>(null);
+
+  const handleMouseMove = (event: React.MouseEvent<SVGSVGElement>) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    // Calculate the position of the mouse relative to the SVG
+    const rect = svg.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+
+    // Find the closest data point based on the x position
+    const bisect = d3.bisector((d: DataPoint) => xScale(d.x)).center;
+    const index = bisect(dataset, x);
+
+    const closestPoint = dataset[index];
+    setTooltip({
+      x: xScale(closestPoint.x),
+      y: yScale(closestPoint.y),
+      value: closestPoint.y,
+    } as LineChartTooltipProps);
+  };
+
+  const handleMouseOut = () => {
+    setTooltip(null);
+  };
+
+  const lineColor =
+    type === 'nominal' || type === 'trending' || type === 'start-end'
+      ? gistvisSpec.unitSegmentSpec.attribute === 'positive'
+        ? 'green'
+        : gistvisSpec.unitSegmentSpec.attribute === 'negative'
+        ? 'red'
+        : 'grey'
+      : colorScale(dataSpec[0].categoryValue);
+
+  const uid =
+    gistvisSpec.unitSegmentSpec.insightType + '-' + gistvisSpec.unitSegmentSpec.attribute + '-' + gistvisSpec.id;
+  return (
+    <Tooltip title={tooltip != null ? getTooltipContnet(tooltip.value) : ''} placement="bottom" color="#ffffff">
+      <svg
+        ref={svgRef}
+        width={lineChartWidth + SVG_INTERVAL}
+        height={SVG_HEIGHT}
+        // style={zoomedIn ? zoomedStyle.zoomedIn : zoomedStyle.normal}
+        // onMouseEnter={handleZoomIn}
+        // onMouseLeave={handleZoomOut}
+        onMouseMove={handleMouseMove}
+        onMouseOut={handleMouseOut}
+      >
+        <path d={areaGenerator(dataset) || undefined} fill={`url(#${uid}-areaGradient`} />
+        <path d={lineGenerator(dataset) || undefined} fill="none" strokeWidth={1.5} />
+        <defs>
+          <linearGradient id={`${uid}-areaGradient`} x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stopColor={lineColor} stopOpacity="1" />
+            <stop offset="100%" stopColor={lineColor} stopOpacity="0.2" />
+          </linearGradient>
+        </defs>
+
+        {gistvisSpec.unitSegmentSpec.attribute === 'invariable' && (
+          <g>
+            <line
+              x1={SVG_PADDING}
+              y1={lineChartHeight / 2}
+              x2={lineChartWidth - SVG_PADDING}
+              y2={lineChartHeight / 2}
+              stroke="grey"
+              strokeWidth={1}
+              strokeDasharray="4,4"
+            />
+          </g>
+        )}
+
+        {type === 'trending' && (
+          <path
+            d={lineGeneratorDifference(differenceLineDataset) || undefined}
+            fill="none"
+            stroke={lineColor}
+            strokeWidth={1}
+            markerStart={`url(#arrow-start-${lineColor})`}
+            markerEnd={`url(#arrow-end-${lineColor})`}
+          />
+        )}
+
+        <defs>
+          <marker
+            id={`arrow-end-${lineColor}`}
+            markerWidth="4"
+            markerHeight="4"
+            refX="3"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M0,0 L0,4 L4,2 z" fill={lineColor} />
+          </marker>
+        </defs>
+
+        <defs>
+          <marker
+            id={`arrow-start-${lineColor}`}
+            markerWidth="4"
+            markerHeight="4"
+            refX="1"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
+          </marker>
+        </defs>
+
+        <path d={lineGenerator(dataset) || undefined} fill="none" stroke={lineColor} strokeWidth={1} />
+        {tooltip && <circle cx={tooltip.x} cy={tooltip.y} r={2} fill="black" opacity={0.9} />}
+      </svg>
+    </Tooltip>
+  );
+  // return <>{visElement}</>;
+};
+
+export default Line;

--- a/packages/gist-wsv/src/components/visualizer/wordScaleVis/vBarChart.tsx
+++ b/packages/gist-wsv/src/components/visualizer/wordScaleVis/vBarChart.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import * as d3 from 'd3';
+import { SVG_HEIGHT, SVG_UNIT_WIDTH } from '../constants';
+import { ChartProps, DataSpec, InsightType } from '../types';
+import { Tooltip } from 'antd';
+
+const VerticalBarChart = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }: ChartProps) => {
+  const [hoveredUniqueId, setHoveredUniqueId] = useState<string | null>(null);
+  const dataSpec = gistvisSpec.dataSpec ?? [];
+
+  const verticalBarChartWidth = SVG_UNIT_WIDTH * dataSpec.length;
+
+  const datasetMap: { [key in InsightType]?: number[] } = {
+    rank: dataSpec.map((d: DataSpec) => dataSpec.length + 1 - d.valueValue),
+    comparison: dataSpec.map((d: DataSpec) => d.valueValue),
+  };
+
+  const dataset = datasetMap[gistvisSpec.unitSegmentSpec.insightType] ?? [];
+
+  const xScale = d3.scaleLinear().domain([0, dataset.length]).range([0, verticalBarChartWidth]);
+  const yScale = d3
+    .scaleLinear()
+    .domain([0, d3.max(dataset) ?? 1])
+    .range([SVG_HEIGHT, 0]);
+
+  const knownCategories = dataSpec.map((d: DataSpec, i: number) => {
+    const uniqueId = `${d.categoryValue}-${d.valueKey}-${d.valueValue}`;
+    const isHovered = uniqueId === hoveredUniqueId;
+    const hoverStyle = {
+      opacity: isHovered ? 1 : 0.5,
+      transition: 'opacity 0.3s',
+    };
+    return (
+      <rect
+        key={uniqueId}
+        x={xScale(i)}
+        y={yScale(dataset[i])}
+        width={SVG_UNIT_WIDTH}
+        height={SVG_HEIGHT - yScale(dataset[i])}
+        fill={d.categoryValue !== 'placeholder' ? colorScale(d.categoryValue) : 'grey'}
+        style={hoverStyle}
+        onMouseOver={() => {
+          setSelectedEntity(d.categoryValue);
+          setHoveredUniqueId(uniqueId);
+        }}
+        onMouseOut={() => {
+          setSelectedEntity('');
+          setHoveredUniqueId(null);
+        }}
+      />
+    );
+  });
+
+  const getToolTipContent = () => {
+    if (hoveredUniqueId === null) {
+      return null;
+    }
+
+    if (selectedEntity === 'placeholder') {
+      return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
+    }
+
+    if (gistvisSpec.unitSegmentSpec.insightType === 'comparison') {
+      const currentCase = dataSpec.find((d) => `${d.categoryValue}-${d.valueKey}-${d.valueValue}` === hoveredUniqueId);
+      if (!currentCase) {
+        return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
+      }
+      const refCase = dataSpec.find((d) => d !== currentCase) || dataSpec[0];
+      const diff = Math.abs(currentCase.valueValue - refCase.valueValue);
+      if (refCase.categoryValue === selectedEntity) {
+        return (
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            The difference between{' '}
+            <span style={{ color: colorScale(refCase.categoryValue) }}>
+              {refCase.categoryValue} ({refCase.valueValue})
+            </span>{' '}
+            and {selectedEntity} ({currentCase.valueValue}) is {diff}.
+          </div>
+        );
+      } else {
+        return (
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            The difference between{' '}
+            <span style={{ color: colorScale(refCase.categoryValue) }}>
+              {refCase.categoryValue} ({refCase.valueValue})
+            </span>{' '}
+            and{' '}
+            <span style={{ color: colorScale(selectedEntity) }}>
+              {selectedEntity} ({currentCase.valueValue})
+            </span>{' '}
+            is {diff}.
+          </div>
+        );
+      }
+    } else if (gistvisSpec.unitSegmentSpec.insightType === 'rank') {
+      const rankData = dataSpec.find((d) => `${d.categoryValue}-${d.valueKey}-${d.valueValue}` === hoveredUniqueId);
+      const rank = rankData?.valueValue;
+      if (!rankData || rank === undefined) {
+        return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Rank</div>;
+      }
+      return (
+        <div style={{ lineHeight: 1.1, fontSize: '14px', color: colorScale(selectedEntity), fontWeight: 'bold' }}>
+          {rankData.valueKey + ' ' + rank + ': ' + selectedEntity}
+        </div>
+      );
+    }
+  };
+
+  const visElement = (
+    <Tooltip title={getToolTipContent()} placement="bottom" color="#ffffff">
+      <svg height={SVG_HEIGHT} width={verticalBarChartWidth}>
+        {knownCategories && [...knownCategories]}
+      </svg>
+    </Tooltip>
+  );
+
+  return <>{visElement}</>;
+};
+
+export default VerticalBarChart;

--- a/packages/gist-wsv/src/index.ts
+++ b/packages/gist-wsv/src/index.ts
@@ -1,0 +1,2 @@
+export { GistViewer } from './App'
+export type { GistViewerProps } from './App'

--- a/packages/gist-wsv/src/index.ts
+++ b/packages/gist-wsv/src/index.ts
@@ -1,2 +1,24 @@
-export { GistViewer } from './App'
-export type { GistViewerProps } from './App'
+export { GistViewer } from './App';
+export * from './components/visualizer/renderer/rendererList';
+export * from './components/visualizer/wordScaleVis/chartList';
+export type { GistViewerProps } from './App';
+
+// Export simplified interface components
+export {
+  SimpleLine,
+  SimpleBar,
+  SimpleStackedBar,
+  SimpleMaxMin,
+} from './components/visualizer/wordScaleVis/interface';
+
+// Export types for simplified interface
+export type {
+  SimpleLineChartProps,
+  SimpleBarChartProps,
+  SimpleStackedBarChartProps,
+  SimpleMaxMinProps,
+  DataPoint,
+  TrendType,
+  TrendAttribute,
+  BarType,
+} from './components/visualizer/wordScaleVis/interface';

--- a/packages/gist-wsv/src/main.tsx
+++ b/packages/gist-wsv/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/packages/gist-wsv/src/style/page.css
+++ b/packages/gist-wsv/src/style/page.css
@@ -1,0 +1,147 @@
+.article {
+  position: absolute;
+  top: 65%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  overflow: auto;
+  min-height: 600px;
+}
+
+.text {
+  font-size: medium;
+  font-style: bold;
+  font-weight: bold;
+}
+
+.pos_text {
+  font-size: medium;
+  font-style: normal;
+  color: crimson;
+  font-weight: bold;
+  font-size: 2ch;
+  margin-right: 5px;
+}
+
+.neg_text {
+  font-size: medium;
+  font-style: normal;
+  color: limegreen;
+  font-weight: bold;
+  font-size: 2ch;
+  margin-right: 5px;
+}
+
+.r_text {
+  font-size: medium;
+  font-style: normal;
+  font-weight: bold;
+  margin-right: 5px;
+}
+
+.spec_value {
+  font-family: sans-serif;
+  font-size: 2ch;
+  font-style: normal;
+  font-weight: 550;
+}
+
+.ano_value {
+  font-family: sans-serif;
+  font-size: normal;
+  font-style: normal;
+  color: red;
+}
+
+.max_value {
+  font-family: sans-serif;
+  font-size: normal;
+  font-style: normal;
+  color: red;
+  font-weight: bold;
+}
+
+.min_value {
+  font-family: sans-serif;
+  font-size: normal;
+  font-style: normal;
+  color: green;
+  font-weight: bold;
+}
+
+.title {
+  font-size: 80px;
+  font: bolder;
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.input_container {
+  position: absolute;
+  top: 20%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.input {
+  width: 500px;
+  height: 30px;
+}
+
+.input_button {
+  width: 100px;
+  height: 35px;
+  position: relative;
+  left: 2px;
+  display: inline-block;
+  font-size: 16px;
+  color: #fff;
+  background-color: #4b0082;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  font-family: Georgia;
+  transition: background-color 0.3s;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
+}
+/* span {
+  line-height: 30px; 
+  white-space: pre-wrap;
+  font-weight: bold;
+} */
+
+.ant-carousel .slick-prev,
+.ant-carousel .slick-next,
+.ant-carousel .slick-prev:hover,
+.ant-carousel .slick-next:hover,
+.ant-carousel .slick-prev:focus,
+.ant-carousel .slick-next:focus {
+  font-size: inherit;
+  color: rgba(76, 144, 226, 0.3) !important;
+}
+
+.ant-carousel .slick-prev::before {
+  color: rgba(76, 144, 226, 0.3) !important;
+}
+
+.slick-arrow.slick-prev {
+  font-size: 20px !important;
+}
+
+.ant-carousel .slick-next::before {
+  color: rgba(76, 144, 226, 0.3) !important;
+}
+
+.slick-arrow.slick-next {
+  font-size: 20px !important;
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/packages/gist-wsv/tsconfig.app.json
+++ b/packages/gist-wsv/tsconfig.app.json
@@ -1,26 +1,22 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "moduleResolution": "node",
     "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
     "jsx": "react-jsx",
-
-    /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "declaration": true,
+    "declarationDir": "./dist",
+    "outDir": "./dist",
+    "emitDeclarationOnly": true,
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/gist-wsv/tsconfig.json
+++ b/packages/gist-wsv/tsconfig.json
@@ -3,5 +3,9 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./dist",
+  }
 }

--- a/packages/gist-wsv/tsconfig.node.json
+++ b/packages/gist-wsv/tsconfig.node.json
@@ -1,24 +1,12 @@
 {
   "compilerOptions": {
-    // "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2023"],
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "module": "ESNext",
+    "moduleResolution": "node",
     "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    // "noUncheckedSideEffectImports": true
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/gist-wsv/vite.config.js
+++ b/packages/gist-wsv/vite.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+// https://vite.dev/config/
+export default defineConfig({
+    plugins: [react()],
+    build: {
+        lib: {
+            entry: resolve(__dirname, 'src/index.ts'),
+            name: 'GistWsv',
+            fileName: (format) => `gist-wsv.${format}.js`,
+            formats: ['es', 'umd']
+        },
+        rollupOptions: {
+            external: ['react', 'react-dom'],
+            output: {
+                globals: {
+                    react: 'React',
+                    'react-dom': 'ReactDOM'
+                }
+            }
+        }
+    }
+});

--- a/packages/gist-wsv/vite.config.ts
+++ b/packages/gist-wsv/vite.config.ts
@@ -1,7 +1,25 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'GistWsv',
+      fileName: (format) => `gist-wsv.${format}.js`,
+      formats: ['es', 'umd']
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM'
+        }
+      }
+    }
+  }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,15 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@ant-design/icons':
+        specifier: '>=5.0.0'
+        version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@eslint/js':
         specifier: ^9.19.0
         version: 9.20.0
+      '@types/d3':
+        specifier: ^7.0.0
+        version: 7.4.3
       '@types/react':
         specifier: ^18.2.0
         version: 18.3.18
@@ -87,6 +93,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.18
         version: 0.4.19(eslint@9.20.1(jiti@1.21.7))
+      fuse.js:
+        specifier: '>=6.0.0'
+        version: 7.1.0
       globals:
         specifier: ^15.14.0
         version: 15.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 0.4.19(eslint@8.57.1)
       eslint-plugin-unused-imports:
         specifier: ^4.1.4
-        version: 4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)
+        version: 4.1.4(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -165,6 +165,9 @@ importers:
       fuse.js:
         specifier: ^7.0.0
         version: 7.1.0
+      gist-wsv:
+        specifier: workspace:*
+        version: link:../packages/gist-wsv
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
@@ -1940,28 +1943,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@20.4.5':
     resolution: {integrity: sha512-bTqySYxbfV8sPq2MZciOFYOSvzS0pBksV9ELJEW5QJZ1NUqOIWQW/sgBSdeprt0qMJtn3fov6Wro0liWOQRUZQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@20.4.5':
     resolution: {integrity: sha512-dxJCRESkWGMNUWM28lT9p8Ap2okM/HU6o9jiZhvMh6D9sdqKY73cg9RUoLu2rAvFMTUUPqNku6qsyOCYpJ9GXA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@20.4.5':
     resolution: {integrity: sha512-Vaqeo/DyUu10SJRHLH5Nb6FOYdwprpQAkvnm9JflQB0XqVnywUftvjnadQ2kOWbWU/rL+zh1XKs6Pn+YtcuRkQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@20.4.5':
     resolution: {integrity: sha512-qf+9goWiUwQAtZwpW6A5x0uJYAJfbbIaT8kVnfT/feDN/Z0rZJ93KJW0QmKPGb41LALcUipVYiUC8PU/8BAmCQ==}
@@ -2150,61 +2149,51 @@ packages:
     resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.8':
     resolution: {integrity: sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.8':
     resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.8':
     resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
     resolution: {integrity: sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
     resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.8':
     resolution: {integrity: sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.8':
     resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.8':
     resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.8':
     resolution: {integrity: sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.8':
     resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
@@ -9734,41 +9723,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.24.1
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5))(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.24.1
-      eslint: 9.20.1(jiti@1.21.7)
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -9783,6 +9737,23 @@ snapshots:
       natural-compare: 1.4.0
       ts-api-utils: 2.0.1(typescript@5.7.3)
       typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5))(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 8.24.1
+      '@typescript-eslint/type-utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.24.1
+      eslint: 9.20.1(jiti@1.21.7)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 2.0.1(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9823,18 +9794,6 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.24.1
-      debug: 4.4.0
-      eslint: 8.57.1
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9895,18 +9854,6 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/type-utils@8.24.1(eslint@8.57.1)(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
-      debug: 4.4.0
-      eslint: 8.57.1
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/type-utils@8.24.1(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
@@ -10019,18 +9966,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@typescript-eslint/utils@8.24.1(eslint@8.57.1)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      eslint: 8.57.1
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/utils@8.24.1(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
@@ -11836,11 +11771,11 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
 
   eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1):
     dependencies:
@@ -12468,7 +12403,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.7.9)
+      retry-axios: 2.6.0(axios@1.7.9(debug@4.4.0))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -14813,7 +14748,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.7.9):
+  retry-axios@2.6.0(axios@1.7.9(debug@4.4.0)):
     dependencies:
       axios: 1.7.9(debug@4.4.0)
 
@@ -15464,7 +15399,7 @@ snapshots:
 
   typescript-eslint@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5))(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5))(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
       '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
       '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
       eslint: 9.20.1(jiti@1.21.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,7 @@ importers:
         specifier: ^7.0.0
         version: 7.1.0
       gist-wsv:
-        specifier: workspace:*
+        specifier: file:../packages/gist-wsv
         version: link:../packages/gist-wsv
       html-to-text:
         specifier: ^9.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.1.1(@types/node@22.13.4)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
+      antd:
+        specifier: ^5.16.0
+        version: 5.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
       eslint:
         specifier: ^9.19.0
         version: 9.20.1(jiti@1.21.7)
@@ -85,11 +91,11 @@ importers:
         specifier: ^15.14.0
         version: 15.15.0
       typescript:
-        specifier: ~4.9.5
-        version: 4.9.5
+        specifier: 5.7.3
+        version: 5.7.3
       typescript-eslint:
         specifier: ^8.22.0
-        version: 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+        version: 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       vite:
         specifier: ^6.1.0
         version: 6.1.1(@types/node@22.13.4)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)
@@ -9740,20 +9746,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5))(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3))(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
       eslint: 9.20.1(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9809,15 +9815,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)':
+  '@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
       debug: 4.4.0
       eslint: 9.20.1(jiti@1.21.7)
-      typescript: 4.9.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9866,14 +9872,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       debug: 4.4.0
       eslint: 9.20.1(jiti@1.21.7)
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9906,20 +9912,6 @@ snapshots:
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.24.1(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/visitor-keys': 8.24.1
-      debug: 4.4.0
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.1
-      ts-api-utils: 2.0.1(typescript@4.9.5)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9978,14 +9970,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)':
+  '@typescript-eslint/utils@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.1(jiti@1.21.7))
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       eslint: 9.20.1(jiti@1.21.7)
-      typescript: 4.9.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15264,10 +15256,6 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.0.1(typescript@4.9.5):
-    dependencies:
-      typescript: 4.9.5
-
   ts-api-utils@2.0.1(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
@@ -15397,13 +15385,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5):
+  typescript-eslint@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5))(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3))(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       eslint: 9.20.1(jiti@1.21.7)
-      typescript: 4.9.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 

--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "gist-wsv": "workspace:*",
     "@ant-design/icons": "^5.6.1",
     "@browserbasehq/stagehand": "^1.12.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "gist-wsv": "workspace:*",
+    "gist-wsv": "file:../packages/gist-wsv",
     "@ant-design/icons": "^5.6.1",
     "@browserbasehq/stagehand": "^1.12.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -3,6 +3,7 @@ import HomePage from './userstudy/homePage';
 import InteractivePage from './userstudy/articlePage';
 import PublicityPage from './demo/Demo';
 import LLMConfigurationPage from './demo/LLMConf';
+import GistTest from './demo/GistTest';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 const App = () => {
@@ -12,6 +13,7 @@ const App = () => {
         <Routes>
           {/* <Route path="/" element={<HomePage />} /> */}
           <Route path="/" element={<PublicityPage />} />
+          <Route path="/gisttest" element={<GistTest />} />
           {/* <Route path="/publicity" element={<PublicityPage />} /> */}
           <Route path="/interactive" element={<HomePage />} />
           <Route path="/interactive/:pageType/:pageId" element={<InteractivePage />} />

--- a/site/src/demo/GistTest.tsx
+++ b/site/src/demo/GistTest.tsx
@@ -1,11 +1,132 @@
 import React from 'react';
-import { GistViewer } from 'gist-wsv';
+import { SimpleLine, SimpleBar, SimpleStackedBar, SimpleMaxMin } from 'gist-wsv';
 
 export const GistTest: React.FC = () => {
+  const lineData = [
+    { x: 0, y: 0.5, label: 'Jan' },
+    { x: 1, y: 0.8, label: 'Feb' },
+    { x: 2, y: 0.2, label: 'Mar' },
+  ];
+
+  const barData = [
+    { x: 0, y: 30, label: 'group A' },
+    { x: 1, y: 50, label: 'group B' },
+    { x: 2, y: 20, label: 'group C' },
+  ];
+
+  const stackedData = [
+    { category: 'category 1', values: [30, 20] },
+    { category: 'category 2', values: [50, 30] },
+  ];
+
   return (
     <div style={{ margin: '20px' }}>
       <h2>Gist WSV Test</h2>
-      <GistViewer text="This is a test of the gist-wsv component!" />
+      
+      <div style={{ marginBottom: '30px' }}>
+        <h3>1. SimpleLine</h3>
+        <div style={{ marginBottom: '10px' }}>Trend-upward</div>
+        <SimpleLine 
+          data={lineData}
+          type="trending"
+          attribute="positive"
+          color="#1890ff"
+        />
+        <div style={{ marginBottom: '10px' }}>Trend-downward</div>
+        <SimpleLine 
+          data={lineData}
+          type="trending"
+          attribute="negative"
+          color="#1890ff"
+        />
+
+        <div style={{ marginBottom: '10px' }}>common</div>
+        <SimpleLine 
+          data={lineData}
+          type="actual"
+          color="#52c41a"
+        />
+      </div>
+
+      <div style={{ marginBottom: '30px' }}>
+        <h3>2. SimpleBar</h3>
+        <div style={{ marginBottom: '10px' }}>comparison - monocolor</div>
+        <SimpleBar
+          data={barData}
+          type="comparison"
+          color="#1890ff"
+        />
+
+        <div style={{ marginBottom: '10px' }}>comparison - multicolors</div>
+        <SimpleBar
+          data={barData}
+          type="comparison"
+          colors={['#1890ff', '#13c2c2', '#52c41a']}
+        />
+
+        <div style={{ marginBottom: '10px' }}>rank - gradient</div>
+        <SimpleBar
+          data={barData}
+          type="rank"
+          colors={['#722ed1', '#2f54eb', '#1890ff']}
+        />
+      </div>
+
+      <div style={{ marginBottom: '30px' }}>
+        <h3>3. SimpleStackedBar</h3>
+        <SimpleStackedBar
+          data={stackedData}
+          colors={['#1890ff', '#13c2c2']}
+        />
+      </div>
+
+      <div style={{ marginBottom: '30px' }}>
+        <h3>4. SimpleMaxMin</h3>
+        <div style={{ marginBottom: '10px' }}>maximum</div>
+        <SimpleMaxMin
+          min={0}
+          max={100}
+          current={80}
+        />
+
+        <div style={{ marginBottom: '10px' }}>minimum</div>
+        <SimpleMaxMin
+          min={0}
+          max={100}
+          current={20}
+        />
+      </div>
+
+      <div>
+        <h3>README</h3>
+        <pre style={{ background: '#f5f5f5', padding: '15px', borderRadius: '4px' }}>
+{`// 1. import
+import { SimpleLine, SimpleBar, SimpleStackedBar, SimpleMaxMin } from 'gist-wsv';
+
+// 2. prepare data
+const data = [
+  { x: 0, y: 0.5, label: 'Jan' },
+  { x: 1, y: 0.8, label: 'Feb' },
+  { x: 2, y: 0.2, label: 'Mar' },
+];
+
+// 3. using
+<SimpleLine 
+  data={data}
+  type="trending"  // 可选: actual | nominal | trending | start-end
+  attribute="positive"  // 可选: positive | negative | invariable
+  color="#1890ff"  // 可选
+/>
+
+<SimpleBar
+  data={data}
+  type="comparison"  // comparison | rank
+  color="#1890ff"
+  colors={['#1890ff', '#13c2c2', '#52c41a']}
+/>
+`}
+        </pre>
+      </div>
     </div>
   );
 };

--- a/site/src/demo/GistTest.tsx
+++ b/site/src/demo/GistTest.tsx
@@ -113,9 +113,9 @@ const data = [
 // 3. using
 <SimpleLine 
   data={data}
-  type="trending"  // 可选: actual | nominal | trending | start-end
-  attribute="positive"  // 可选: positive | negative | invariable
-  color="#1890ff"  // 可选
+  type="trending"  // actual | nominal | trending | start-end
+  attribute="positive"  // positive | negative | invariable
+  color="#1890ff"
 />
 
 <SimpleBar

--- a/site/src/demo/GistTest.tsx
+++ b/site/src/demo/GistTest.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { GistViewer } from 'gist-wsv';
+
+export const GistTest: React.FC = () => {
+  return (
+    <div style={{ margin: '20px' }}>
+      <h2>Gist WSV Test</h2>
+      <GistViewer text="This is a test of the gist-wsv component!" />
+    </div>
+  );
+};
+
+export default GistTest;

--- a/site/src/demo/GistTest.tsx
+++ b/site/src/demo/GistTest.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { SimpleLine, SimpleBar, SimpleStackedBar, SimpleMaxMin } from 'gist-wsv';
+import { Layout, Typography, Card, Space, theme } from 'antd';
+
+const { Content } = Layout;
+const { Title, Text, Paragraph } = Typography;
 
 export const GistTest: React.FC = () => {
+  const { token } = theme.useToken();
+  
   const lineData = [
     { x: 0, y: 0.5, label: 'Jan' },
     { x: 1, y: 0.8, label: 'Feb' },
@@ -20,86 +26,112 @@ export const GistTest: React.FC = () => {
   ];
 
   return (
-    <div style={{ margin: '20px' }}>
-      <h2>Gist WSV Test</h2>
-      
-      <div style={{ marginBottom: '30px' }}>
-        <h3>1. SimpleLine</h3>
-        <div style={{ marginBottom: '10px' }}>Trend-upward</div>
-        <SimpleLine 
-          data={lineData}
-          type="trending"
-          attribute="positive"
-          color="#1890ff"
-        />
-        <div style={{ marginBottom: '10px' }}>Trend-downward</div>
-        <SimpleLine 
-          data={lineData}
-          type="trending"
-          attribute="negative"
-          color="#1890ff"
-        />
+    <Layout>
+      <Content style={{ padding: '24px', maxWidth: 1200, margin: '0 auto' }}>
+        <Space direction="vertical" size="large" style={{ width: '100%' }}>
+          <Title level={2}>Gist WSV Test</Title>
+          
+          <Card title={<Title level={3} style={{ margin: 0 }}>1. SimpleLine</Title>}>
+            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+              <Layout>
+                <Text>Trend-upward</Text>
+                <SimpleLine 
+                  data={lineData}
+                  type="trending"
+                  attribute="positive"
+                  color="#1890ff"
+                />
+              </Layout>
+              
+              <Layout>
+                <Text>Trend-downward</Text>
+                <SimpleLine 
+                  data={lineData}
+                  type="trending"
+                  attribute="negative"
+                  color="#1890ff"
+                />
+              </Layout>
 
-        <div style={{ marginBottom: '10px' }}>common</div>
-        <SimpleLine 
-          data={lineData}
-          type="actual"
-          color="#52c41a"
-        />
-      </div>
+              <Layout>
+                <Text>common</Text>
+                <SimpleLine 
+                  data={lineData}
+                  type="actual"
+                  color="#52c41a"
+                />
+              </Layout>
+            </Space>
+          </Card>
 
-      <div style={{ marginBottom: '30px' }}>
-        <h3>2. SimpleBar</h3>
-        <div style={{ marginBottom: '10px' }}>comparison - monocolor</div>
-        <SimpleBar
-          data={barData}
-          type="comparison"
-          color="#1890ff"
-        />
+          <Card title={<Title level={3} style={{ margin: 0 }}>2. SimpleBar</Title>}>
+            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+              <Layout>
+                <Text>comparison - monocolor</Text>
+                <SimpleBar
+                  data={barData}
+                  type="comparison"
+                  color="#1890ff"
+                />
+              </Layout>
 
-        <div style={{ marginBottom: '10px' }}>comparison - multicolors</div>
-        <SimpleBar
-          data={barData}
-          type="comparison"
-          colors={['#1890ff', '#13c2c2', '#52c41a']}
-        />
+              <Layout>
+                <Text>comparison - multicolors</Text>
+                <SimpleBar
+                  data={barData}
+                  type="comparison"
+                  colors={['#1890ff', '#13c2c2', '#52c41a']}
+                />
+              </Layout>
 
-        <div style={{ marginBottom: '10px' }}>rank - gradient</div>
-        <SimpleBar
-          data={barData}
-          type="rank"
-          colors={['#722ed1', '#2f54eb', '#1890ff']}
-        />
-      </div>
+              <Layout>
+                <Text>rank - gradient</Text>
+                <SimpleBar
+                  data={barData}
+                  type="rank"
+                  colors={['#722ed1', '#2f54eb', '#1890ff']}
+                />
+              </Layout>
+            </Space>
+          </Card>
 
-      <div style={{ marginBottom: '30px' }}>
-        <h3>3. SimpleStackedBar</h3>
-        <SimpleStackedBar
-          data={stackedData}
-          colors={['#1890ff', '#13c2c2']}
-        />
-      </div>
+          <Card title={<Title level={3} style={{ margin: 0 }}>3. SimpleStackedBar</Title>}>
+            <SimpleStackedBar
+              data={stackedData}
+              colors={['#1890ff', '#13c2c2']}
+            />
+          </Card>
 
-      <div style={{ marginBottom: '30px' }}>
-        <h3>4. SimpleMaxMin</h3>
-        <div style={{ marginBottom: '10px' }}>maximum</div>
-        <SimpleMaxMin
-          min={0}
-          max={100}
-          current={80}
-        />
+          <Card title={<Title level={3} style={{ margin: 0 }}>4. SimpleMaxMin</Title>}>
+            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+              <Layout>
+                <Text>maximum</Text>
+                <SimpleMaxMin
+                  min={0}
+                  max={100}
+                  current={80}
+                />
+              </Layout>
 
-        <div style={{ marginBottom: '10px' }}>minimum</div>
-        <SimpleMaxMin
-          min={0}
-          max={100}
-          current={20}
-        />
-      </div>
+              <Layout>
+                <Text>minimum</Text>
+                <SimpleMaxMin
+                  min={0}
+                  max={100}
+                  current={20}
+                />
+              </Layout>
+            </Space>
+          </Card>
 
-      <div>
-        <h3>README</h3>
-        <pre style={{ background: '#f5f5f5', padding: '15px', borderRadius: '4px' }}>
+          <Card title={<Title level={3} style={{ margin: 0 }}>README</Title>}>
+            <Paragraph>
+              <pre style={{ 
+                background: token.colorFillTertiary,
+                padding: token.padding,
+                borderRadius: token.borderRadius,
+                margin: 0
+              }}>
 {`// 1. import
 import { SimpleLine, SimpleBar, SimpleStackedBar, SimpleMaxMin } from 'gist-wsv';
 
@@ -123,11 +155,13 @@ const data = [
   type="comparison"  // comparison | rank
   color="#1890ff"
   colors={['#1890ff', '#13c2c2', '#52c41a']}
-/>
-`}
-        </pre>
-      </div>
-    </div>
+/>`}
+              </pre>
+            </Paragraph>
+          </Card>
+        </Space>
+      </Content>
+    </Layout>
   );
 };
 

--- a/site/src/types/gist-wsv.d.ts
+++ b/site/src/types/gist-wsv.d.ts
@@ -1,0 +1,92 @@
+declare module 'gist-wsv' {
+  import { ScaleOrdinal } from 'd3';
+  import { FC } from 'react';
+
+  export type VisInsightType = 'comparison' | 'trend' | 'rank' | 'proportion' | 'extreme' | 'value';
+  export type InsightType = VisInsightType | 'noType';
+  export type ExtremeAttribute = 'maximum' | 'minimum';
+  export type TrendAttribute = 'positive' | 'negative' | 'invariable';
+  export type BarType = 'comparison' | 'rank';
+  export type Attribute = ExtremeAttribute | TrendAttribute;
+
+  export type DataSpec = {
+    categoryKey: string;
+    categoryValue: string;
+    valueKey: string;
+    valueValue: number;
+  };
+
+  export type UnitSegmentSpec = {
+    insightType: InsightType;
+    segmentIdx: number;
+    context: string;
+    attribute?: Attribute;
+    inSituPosition?: string[];
+  };
+
+  export interface GistvisSpec {
+    id: string;
+    unitSegmentSpec: UnitSegmentSpec;
+    dataSpec?: DataSpec[];
+  }
+
+  export interface DataPoint {
+    x: number;
+    y: number;
+    label?: string;
+  }
+
+  export type TrendType = 'actual' | 'nominal' | 'trending' | 'start-end';
+
+  export interface LineChartProps {
+    gistvisSpec: GistvisSpec;
+    visualizeData: DataPoint[];
+    type: TrendType;
+    colorScale: ScaleOrdinal<string, string>;
+    selectedEntity: string;
+    setSelectedEntity: (entity: string) => void;
+  }
+
+  export interface SimpleLineChartProps {
+    data: DataPoint[];
+    type?: TrendType;
+    attribute?: TrendAttribute;
+    color?: string;
+    width?: number;
+    height?: number;
+  }
+
+  export interface SimpleBarChartProps {
+    data: DataPoint[];
+    type?: BarType;
+    color?: string;
+    colors?: string[];
+    width?: number;
+    height?: number;
+  }
+
+  export interface SimpleStackedBarChartProps {
+    data: {
+      category: string;
+      values: number[];
+    }[];
+    colors?: string[];
+    width?: number;
+    height?: number;
+  }
+
+  export interface SimpleMaxMinProps {
+    min: number;
+    max: number;
+    current: number;
+    color?: string;
+    width?: number;
+    height?: number;
+  }
+
+  export const LineChart: FC<LineChartProps>;
+  export const SimpleLine: FC<SimpleLineChartProps>;
+  export const SimpleBar: FC<SimpleBarChartProps>;
+  export const SimpleStackedBar: FC<SimpleStackedBarChartProps>;
+  export const SimpleMaxMin: FC<SimpleMaxMinProps>;
+}


### PR DESCRIPTION
# Description
- Import gist-wsv to site project as a local package
- Migrate visualizer to project
- Allow users to use components with easier parameters
- Empty the useTrack in the local package
# Files Changed
## Take it easy with so many files changed. Most of them are purely copies.
- `packages/gist-wsv/package.json` and files in `packages/gist-wsv/`: update dependencies
- `packages/gist-wsv/src/`: lots of which is a purely copy from `@site-src/modules/llm` or `@site-src/modules/visualizer`
- `packages/gist-wsv/src/components/visualizer/wordScaleVis/interface/`: simple use of chart components
- `packages/gist-wsv/src/App.tsx`: add a test page in endpoint 'gisttest'
- `site/package.json`: import local package
- `site/src/types/gist-wsv.d.ts`: declare type in the local package
- `site/src/demo/GistTest.tsx`: test page for gist-wsv