### PR TITLE
New `Value` pattern and new `Trend` textual explanation 

### DIFF
--- a/packages/gist-wsv/src/components/wordScaleVis/glyphText.tsx
+++ b/packages/gist-wsv/src/components/wordScaleVis/glyphText.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import * as d3 from 'd3';
 import { SVG_HEIGHT, SVG_PADDING } from '../constants';
 import { ChartProps, DataSpec } from '../types';
 import { Tooltip } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+
+const MAX_DASHES = 10;
+const DASH_WIDTH = 10;
+const DASH_STROKE_WIDTH = 2;
+const DASH_V_SPACING = 5;
+const DASH_H_SPACING = 4;
+const SVG_WIDTH = SVG_PADDING * 2 + DASH_WIDTH * 2 + DASH_H_SPACING;
 
 const GlyphText: React.FC<ChartProps> = ({ gistvisSpec, colorScale, selectedEntity, setSelectedEntity }) => {
   const dataSpec = gistvisSpec.dataSpec ?? [];
-  // process cases with one value only
-  const value = dataSpec.map((d: DataSpec) => d.value)[0];
-  const inSituPosition = gistvisSpec.unitSegmentSpec.inSituPosition ?? [];
 
-  const targetEntity = dataSpec.map((d: DataSpec) => d.breakdown)[0];
-
+  // Function to generate tooltip content
   const getToolTipContent = (value: number, category: string) => {
     const formatter = new Intl.NumberFormat('en-US', {
       minimumFractionDigits: 2,
@@ -32,56 +33,84 @@ const GlyphText: React.FC<ChartProps> = ({ gistvisSpec, colorScale, selectedEnti
     );
   };
 
-  const getVisElement = (value: number, currentEntity: string) => {
+  const getVisElement = (currentValue: number, currentEntity: string) => {
     const hoverStyle = {
       opacity: currentEntity === selectedEntity ? 1 : 0.5,
       transition: 'opacity 0.3s',
     };
-    // if value < 0, then return the value
-    if (value > 0 && value <= 100) {
-      const glyphElementWidth = 6;
-      const numRows = 5;
-      const pointsPerRow = Math.ceil(value / numRows);
 
-      const xScale = d3
-        .scaleLinear()
-        .domain([0, pointsPerRow])
-        .range([SVG_PADDING, glyphElementWidth * pointsPerRow - SVG_PADDING]);
+    // Dynamically calculate scaledValue
+    let scaledValue: number;
+    const absValue = Math.abs(currentValue);
 
-      const yScale = d3
-        .scaleLinear()
-        .domain([0, numRows])
-        .range([SVG_HEIGHT - SVG_PADDING, SVG_PADDING]);
-
-      const points = Array.from({ length: value }, (_, i) => {
-        return {
-          x: xScale(i % pointsPerRow),
-          y: yScale(Math.floor(i / pointsPerRow)),
-        };
-      });
-
-      return (
-        <svg
-          width={glyphElementWidth * pointsPerRow}
-          height={SVG_HEIGHT}
-          style={hoverStyle}
-          onMouseOver={() => setSelectedEntity(currentEntity)}
-          onMouseOut={() => setSelectedEntity('')}
-        >
-          {points.map((point, index) => (
-            <circle key={index} cx={point.x} cy={point.y} r={1.2} fill={colorScale(currentEntity)} />
-          ))}
-        </svg>
-      );
+    if (absValue === 0) {
+      scaledValue = 0;
+    } else if (absValue < 1) {
+      scaledValue = absValue;
     } else {
-      return (
-        <SearchOutlined
-          style={{ ...hoverStyle, color: colorScale(currentEntity) }}
-          onMouseOver={() => setSelectedEntity(currentEntity)}
-          onMouseOut={() => setSelectedEntity('')}
+      const divisor = Math.pow(10, Math.floor(Math.log10(absValue)));
+      scaledValue = absValue / divisor;
+    }
+
+    scaledValue = Math.min(MAX_DASHES, Math.max(0, scaledValue));
+
+    const numFullDashes = Math.floor(scaledValue);
+    const lastDashFraction = scaledValue - numFullDashes;
+    const numTotalDashes = Math.ceil(scaledValue);
+
+    const dashes = [];
+    for (let i = 0; i < numTotalDashes; i++) {
+      // Calculate row and column index (bottom to top, left to right)
+      const rowIndex = i % 5;
+      const colIndex = i < 5 ? 0 : 1;
+
+      const y = SVG_HEIGHT - SVG_PADDING - rowIndex * DASH_V_SPACING - DASH_STROKE_WIDTH / 2;
+      const x1 = SVG_PADDING + colIndex * (DASH_WIDTH + DASH_H_SPACING);
+
+      let currentDashWidth = DASH_WIDTH;
+      // If it's the last dash and needs to be scaled
+      if (i === numFullDashes && lastDashFraction > 0) {
+        currentDashWidth = DASH_WIDTH * lastDashFraction;
+      }
+      // Handle cases where the loop iterates beyond the required full dashes
+      else if (i >= numFullDashes) {
+        if (lastDashFraction === 0 && i === numFullDashes) {
+          // This is a boundary case and might not be strictly necessary due to the loop condition
+        } else {
+          continue; // Skip extra iterations from Math.ceil
+        }
+      }
+
+      if (currentDashWidth <= 0) continue;
+
+      const x2 = x1 + currentDashWidth;
+
+      dashes.push(
+        <line
+          key={i}
+          x1={x1}
+          y1={y}
+          x2={x2}
+          y2={y}
+          stroke={colorScale(currentEntity)}
+          strokeWidth={DASH_STROKE_WIDTH}
+          strokeLinecap="round"
         />
       );
     }
+
+    // Return the SVG container with all the dashes
+    return (
+      <svg
+        width={SVG_WIDTH}
+        height={SVG_HEIGHT}
+        style={hoverStyle}
+        onMouseOver={() => setSelectedEntity(currentEntity)}
+        onMouseOut={() => setSelectedEntity('')}
+      >
+        {dashes}
+      </svg>
+    );
   };
 
   const mainElement = dataSpec.map((d: DataSpec, i: number) => {
@@ -90,22 +119,16 @@ const GlyphText: React.FC<ChartProps> = ({ gistvisSpec, colorScale, selectedEnti
       transition: 'opacity 0.3s',
     };
     return (
-      <Tooltip title={getToolTipContent(d.value, d.breakdown)} placement="bottom" color="#ffffff">
+      <Tooltip
+        title={getToolTipContent(d.value, d.breakdown)}
+        placement="bottom"
+        color="#ffffff"
+        key={d.breakdown || i}
+      >
         {getVisElement(d.value, d.breakdown)}
       </Tooltip>
     );
   });
-
-  // const mainElement = highlightEntity
-  //   .map((d: string, i: number) => {
-  //     const hoverStyle = {
-  //       opacity: d === selectedEntity ? 1 : 0.5,
-  //       transition: "opacity 0.3s",
-  //     };
-  //     return (
-  //       <span>{d}</span>
-  //     );
-  //   });
 
   return <>{mainElement}</>;
 };

--- a/packages/gist-wsv/src/components/wordScaleVis/glyphText.tsx
+++ b/packages/gist-wsv/src/components/wordScaleVis/glyphText.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from 'antd';
 const MAX_DASHES = 10;
 const DASH_WIDTH = 10;
 const DASH_STROKE_WIDTH = 2;
-const DASH_V_SPACING = 5;
+const DASH_V_SPACING = 3;
 const DASH_H_SPACING = 4;
 const SVG_WIDTH = SVG_PADDING * 2 + DASH_WIDTH * 2 + DASH_H_SPACING;
 

--- a/packages/gist-wsv/src/components/wordScaleVis/lineChart.tsx
+++ b/packages/gist-wsv/src/components/wordScaleVis/lineChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import * as d3 from 'd3';
 import { SVG_HEIGHT, SVG_PADDING, SVG_UNIT_WIDTH, SVG_INTERVAL } from '../constants';
 import { DataPoint, LineChartProps } from '../types';
@@ -10,6 +10,9 @@ interface LineChartTooltipProps {
   y: number;
   value: number;
 }
+
+const DATA_PARAM_COLOR = '#003366'; // Color for auxiliary text (Trend indicator/word/connectors/descriptions)
+// Trend/category color (currentLineColor) will be used for breakdown/feature/value/difference
 
 const Line: React.FC<LineChartProps> = ({
   gistvisSpec,
@@ -23,175 +26,267 @@ const Line: React.FC<LineChartProps> = ({
   const dataset = visualizeData;
 
   const svgRef = React.useRef<SVGSVGElement>(null);
+
   const lineChartWidth = type === 'start-end' ? SVG_UNIT_WIDTH * dataset.length * 2 : SVG_UNIT_WIDTH * dataset.length;
   const lineChartHeight = SVG_HEIGHT;
-
-  const dataPosX = dataset[dataset.length - 1].x;
-  const differenceLineDataset: DataPoint[] = [
-    { x: dataPosX, y: dataset[0].y },
-    { x: dataPosX, y: dataset[dataset.length - 1].y },
-  ];
-
+  const dataPosX = dataset[dataset.length - 1]?.x ?? 0;
+  const differenceLineDataset: DataPoint[] =
+    dataset.length > 0
+      ? [
+          { x: dataPosX, y: dataset[0].y },
+          { x: dataPosX, y: dataset[dataset.length - 1].y },
+        ]
+      : [];
   const xScale = d3
     .scaleLinear()
-    .domain(d3.extent(dataset, (d) => d.x) as [number, number])
+    .domain((d3.extent(dataset, (d) => d.x) as [number, number]) || [0, 1])
     .range([SVG_PADDING, lineChartWidth - SVG_PADDING]);
-
   const yScale = d3
     .scaleLinear()
-    .domain(d3.extent(dataset, (d) => d.y) as [number, number])
+    .domain((d3.extent(dataset, (d) => d.y) as [number, number]) || [0, 1])
     .range([lineChartHeight - SVG_PADDING, SVG_PADDING]);
-
   const lineGenerator = d3
     .line<{ x: number; y: number }>()
     .x((d) => xScale(d.x))
     .y((d) => yScale(d.y))
     .curve(gistvisSpec.unitSegmentSpec.attribute === 'invariable' ? d3.curveMonotoneX : d3.curveLinear);
-
   const lineGeneratorDifference = d3
     .line<{ x: number; y: number }>()
     .x((d) => xScale(d.x) + SVG_INTERVAL)
     .y((d) => yScale(d.y));
-
   const areaGenerator = d3
     .area<{ x: number; y: number }>()
     .x((d) => xScale(d.x))
     .y1((d) => yScale(d.y))
     .y0(yScale(0));
 
+  const [tooltip, setTooltip] = useState<LineChartTooltipProps | null>(null);
+
   const getTooltipContnet = (selectionVal: number | null) => {
+    const currentLineColor =
+      type === 'nominal' || type === 'trending' || type === 'start-end'
+        ? gistvisSpec.unitSegmentSpec.attribute === 'positive'
+          ? 'green'
+          : gistvisSpec.unitSegmentSpec.attribute === 'negative'
+            ? 'red'
+            : 'grey'
+        : colorScale(dataSpec[0]?.breakdown ?? 'defaultCategory');
+
+    const baseStyle = {
+      lineHeight: 1.1,
+      fontSize: '14px',
+      fontWeight: 'bold',
+      color: DATA_PARAM_COLOR,
+    };
+
     if (type === 'nominal') {
+      const attribute = gistvisSpec.unitSegmentSpec.attribute;
+      let trendIndicator = '';
+      let trendWord = '';
+      switch (attribute) {
+        case 'positive':
+          trendIndicator = '↗';
+          trendWord = 'increasing';
+          break;
+        case 'negative':
+          trendIndicator = '↘';
+          trendWord = 'decreasing';
+          break;
+        default:
+          trendIndicator = '→';
+          trendWord = 'stable';
+          break;
+      }
+
+      let featureText: string | null = null;
+      let breakdownText: string | null = null;
+      let connectorText: string | null = null;
+      let needsSpaceBeforeBreakdown = false;
+      let needsSpaceBeforeFeature = false;
+
+      if (dataSpec && dataSpec.length > 0) {
+        const firstDataPoint = dataSpec[0];
+        const feature = firstDataPoint.feature || '';
+        const breakdown = firstDataPoint.breakdown || '';
+        if (feature && breakdown) {
+          featureText = feature.replace(/^the\s/i, '');
+          breakdownText = capitalizeFirstLetter(breakdown);
+          connectorText = `'s `;
+          needsSpaceBeforeBreakdown = true;
+          needsSpaceBeforeFeature = false;
+        } else if (feature) {
+          featureText = feature.replace(/^the\s/i, '');
+          connectorText = ` for `;
+          needsSpaceBeforeBreakdown = false;
+          needsSpaceBeforeFeature = false;
+        } else if (breakdown) {
+          breakdownText = capitalizeFirstLetter(breakdown);
+          connectorText = ` related to `;
+          needsSpaceBeforeBreakdown = false;
+          needsSpaceBeforeFeature = false;
+        }
+      }
+
       return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: `${lineColor}`,
-            fontWeight: 'bold',
-          }}
-        >
-          {gistvisSpec.unitSegmentSpec.attribute === 'positive'
-            ? '↗ increasing'
-            : gistvisSpec.unitSegmentSpec.attribute === 'negative'
-              ? '↘ decreasing'
-              : '→ stable'}
+        <div style={baseStyle}>
+          <span>
+            {trendIndicator} {capitalizeFirstLetter(trendWord)}
+          </span>
+          {connectorText && connectorText !== `'s ` && <span>{connectorText}</span>}
+          {breakdownText && (
+            <span style={{ color: currentLineColor }}>
+              {needsSpaceBeforeBreakdown ? ' ' : ''}[{breakdownText}]
+            </span>
+          )}
+          {breakdownText && featureText && connectorText === `'s ` && <span>{connectorText}</span>}
+          {featureText && (
+            <span style={{ color: currentLineColor }}>
+              {' '}
+              {needsSpaceBeforeFeature ? ' ' : ''}[{featureText}]
+            </span>
+          )}
         </div>
       );
     } else if (type === 'trending') {
+      if (!dataSpec || dataSpec.length === 0) return null;
+
+      const trendText = gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increased' : '↘ decreased';
+      const value = dataSpec[0]?.value;
+
       return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: `${lineColor}`,
-            fontWeight: 'bold',
-          }}
-        >
-          {gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increased' : '↘ decreased'} {dataSpec[0].value}
+        <div style={baseStyle}>
+          <span>{trendText}</span>
+          {value != null && <span style={{ color: currentLineColor }}> [{value}]</span>}
         </div>
       );
     } else if (type === 'start-end') {
+      if (!dataSpec || dataSpec.length < 2 || selectionVal === null) return null;
+
+      const startPoint = dataSpec[0];
+      const endPoint = dataSpec[1];
+      const feature = startPoint.feature ? capitalizeFirstLetter(startPoint.feature) : '';
+      const selectedBreakdown = dataSpec.find((d) => d.value === selectionVal)?.breakdown ?? startPoint.breakdown ?? '';
+
+      let description = '';
+      let differenceText: number | string | null = null;
+
+      if (gistvisSpec.unitSegmentSpec.attribute === 'invariable') {
+        description = '. The value remains stable.';
+      } else {
+        const difference = Math.abs(endPoint.value - startPoint.value);
+        const trendWord = gistvisSpec.unitSegmentSpec.attribute === 'positive' ? 'increase' : 'decrease';
+        description = `. The ${trendWord} is `;
+        differenceText = `[${difference}]`;
+      }
+
       return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: `${lineColor}`,
-            fontWeight: 'bold',
-          }}
-        >
-          {capitalizeFirstLetter(dataSpec[0].feature) +
-            ' of ' +
-            dataSpec.find((d) => d.value === selectionVal)?.breakdown +
-            ': ' +
-            selectionVal}
-          {gistvisSpec.unitSegmentSpec.attribute === 'invariable'
-            ? '. The value remains stable.'
-            : `. The ${gistvisSpec.unitSegmentSpec.attribute === 'positive' ? '↗ increase' : '↘ decrease'} is ${Math.abs(
-                dataSpec[1].value - dataSpec[0].value
-              )}.`}
+        <div style={baseStyle}>
+          {feature && <span style={{ color: currentLineColor }}>[{feature}]</span>}
+
+          {feature && selectedBreakdown && <span> of </span>}
+
+          {selectedBreakdown && <span style={{ color: currentLineColor }}>[{selectedBreakdown}]</span>}
+
+          <span>: </span>
+          <span style={{ color: currentLineColor }}>[{selectionVal}]</span>
+          <span>{description}</span>
+          {differenceText !== null && <span style={{ color: currentLineColor }}>{differenceText}</span>}
+
+          {differenceText !== null && <span>.</span>}
         </div>
       );
     } else {
+      if (!dataSpec || dataSpec.length === 0 || selectionVal === null) return null;
+
+      const feature = dataSpec[0].feature ? capitalizeFirstLetter(dataSpec[0].feature) : '';
+      const selectedDatapoint = dataSpec.find((d) => d.value === selectionVal);
+      const selectedBreakdown = selectedDatapoint?.breakdown ?? '';
+
       return (
-        <div
-          style={{
-            lineHeight: 1.1,
-            fontSize: '14px',
-            color: `${lineColor}`,
-            fontWeight: 'bold',
-          }}
-        >
-          {capitalizeFirstLetter(dataSpec[0].feature) +
-            ' of ' +
-            dataSpec.find((d) => d.value === selectionVal)?.breakdown +
-            ': ' +
-            selectionVal}
-          .
+        <div style={baseStyle}>
+          {feature && <span style={{ color: currentLineColor }}>]{feature}]</span>}
+          {feature && selectedBreakdown && <span> of </span>}
+          {selectedBreakdown && <span style={{ color: currentLineColor }}>[{selectedBreakdown}]</span>}
+          <span>: </span>
+          <span style={{ color: currentLineColor }}>[{selectionVal}]</span>
+          <span>.</span>
         </div>
       );
     }
   };
 
-  const [tooltip, setTooltip] = useState<LineChartTooltipProps | null>(null);
-
   const handleMouseMove = (event: React.MouseEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
     if (!svg) return;
-
-    // Calculate the position of the mouse relative to the SVG
     const rect = svg.getBoundingClientRect();
     const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-
-    // Find the closest data point based on the x position
     const bisect = d3.bisector((d: DataPoint) => xScale(d.x)).center;
     const index = bisect(dataset, x);
-
-    const closestPoint = dataset[index];
-    setTooltip({
-      x: xScale(closestPoint.x),
-      y: yScale(closestPoint.y),
-      value: closestPoint.y,
-    } as LineChartTooltipProps);
+    if (index >= 0 && index < dataset.length) {
+      const closestPoint = dataset[index];
+      setTooltip({
+        x: xScale(closestPoint.x),
+        y: yScale(closestPoint.y),
+        value: closestPoint.y,
+      } as LineChartTooltipProps);
+    } else {
+      setTooltip(null);
+    }
   };
-
   const handleMouseOut = () => {
     setTooltip(null);
   };
 
-  const lineColor =
+  const finalLineColor =
     type === 'nominal' || type === 'trending' || type === 'start-end'
       ? gistvisSpec.unitSegmentSpec.attribute === 'positive'
         ? 'green'
         : gistvisSpec.unitSegmentSpec.attribute === 'negative'
           ? 'red'
           : 'grey'
-      : colorScale(dataSpec[0].breakdown);
-
+      : colorScale(dataSpec[0]?.breakdown ?? 'defaultCategory');
   const uid =
     gistvisSpec.unitSegmentSpec.insightType + '-' + gistvisSpec.unitSegmentSpec.attribute + '-' + gistvisSpec.id;
+
   return (
     <Tooltip title={tooltip != null ? getTooltipContnet(tooltip.value) : ''} placement="bottom" color="#ffffff">
       <svg
         ref={svgRef}
         width={lineChartWidth + SVG_INTERVAL}
         height={SVG_HEIGHT}
-        // style={zoomedIn ? zoomedStyle.zoomedIn : zoomedStyle.normal}
-        // onMouseEnter={handleZoomIn}
-        // onMouseLeave={handleZoomOut}
         onMouseMove={handleMouseMove}
         onMouseOut={handleMouseOut}
       >
-        <path d={areaGenerator(dataset) || undefined} fill={`url(#${uid}-areaGradient`} />
-        <path d={lineGenerator(dataset) || undefined} fill="none" strokeWidth={1.5} />
         <defs>
           <linearGradient id={`${uid}-areaGradient`} x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor={lineColor} stopOpacity="1" />
-            <stop offset="100%" stopColor={lineColor} stopOpacity="0.2" />
+            <stop offset="0%" stopColor={finalLineColor} stopOpacity="1" />
+            <stop offset="100%" stopColor={finalLineColor} stopOpacity="0.2" />
           </linearGradient>
+          <marker
+            id={`arrow-end-${finalLineColor}`}
+            markerWidth="4"
+            markerHeight="4"
+            refX="3"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M0,0 L0,4 L4,2 z" fill={finalLineColor} />
+          </marker>
+          <marker
+            id={`arrow-start-${finalLineColor}`}
+            markerWidth="4"
+            markerHeight="4"
+            refX="1"
+            refY="2"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M4,0 L4,4 L0,2 z" fill={finalLineColor} />
+          </marker>
         </defs>
-
+        <path d={areaGenerator(dataset) || undefined} fill={`url(#${uid}-areaGradient`} />
+        <path d={lineGenerator(dataset) || undefined} fill="none" strokeWidth={1.5} />
         {gistvisSpec.unitSegmentSpec.attribute === 'invariable' && (
           <g>
             <line
@@ -205,52 +300,21 @@ const Line: React.FC<LineChartProps> = ({
             />
           </g>
         )}
-
-        {type === 'trending' && (
+        {type === 'trending' && differenceLineDataset.length === 2 && (
           <path
             d={lineGeneratorDifference(differenceLineDataset) || undefined}
             fill="none"
-            stroke={lineColor}
+            stroke={finalLineColor}
             strokeWidth={1}
-            markerStart={`url(#arrow-start-${lineColor})`}
-            markerEnd={`url(#arrow-end-${lineColor})`}
+            markerStart={`url(#arrow-start-${finalLineColor})`}
+            markerEnd={`url(#arrow-end-${finalLineColor})`}
           />
         )}
-
-        <defs>
-          <marker
-            id={`arrow-end-${lineColor}`}
-            markerWidth="4"
-            markerHeight="4"
-            refX="3"
-            refY="2"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M0,0 L0,4 L4,2 z" fill={lineColor} />
-          </marker>
-        </defs>
-
-        <defs>
-          <marker
-            id={`arrow-start-${lineColor}`}
-            markerWidth="4"
-            markerHeight="4"
-            refX="1"
-            refY="2"
-            orient="auto"
-            markerUnits="strokeWidth"
-          >
-            <path d="M4,0 L4,4 L0,2 z" fill={lineColor} />
-          </marker>
-        </defs>
-
-        <path d={lineGenerator(dataset) || undefined} fill="none" stroke={lineColor} strokeWidth={1} />
+        <path d={lineGenerator(dataset) || undefined} fill="none" stroke={finalLineColor} strokeWidth={1} />
         {tooltip && <circle cx={tooltip.x} cy={tooltip.y} r={2} fill="black" opacity={0.9} />}
       </svg>
     </Tooltip>
   );
-  // return <>{visElement}</>;
 };
 
 export default Line;

--- a/packages/gist-wsv/src/renderer/valueTextRenderer.tsx
+++ b/packages/gist-wsv/src/renderer/valueTextRenderer.tsx
@@ -54,10 +54,7 @@ const ValueTextRenderer: React.FC<{ gistvisSpec: GistvisSpec }> = ({ gistvisSpec
         } else if (content.displayType === 'word-scale-vis') {
           return (
             <span onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-              <span key={index}>
-                {content.content}
-                {valueVis}
-              </span>
+              <span key={index}>{valueVis}</span>
             </span>
           );
         } else {


### PR DESCRIPTION
**Problems are raised in [issue](https://github.com/Motion115/GistVis/issues/84).**
### Solutions
- **Trend**:
I have updated the text description for when TrendOptions is nominal. The following format is now used:
``(↗increasing|↘decreasing|→stable) [breakdown]'s [feature]``
Additionally, color contrast has been added to emphasize key information.
![image](https://github.com/user-attachments/assets/56642d36-dcf9-4ff5-b705-03178f33335b)
- **Value**:
Dehaene notes that Bertrand Bourdon studied the human **'sense of number'**. Bourdon found that humans can quickly recognize quantities between 1 and 3. Beyond this range, both the time taken for recognition and the error rate increase as the quantity grows.

Drawing inspiration from this finding, I have developed a visualization method where a single horizontal line represents a **'base unit'**. This base unit's value is typically determined by the place value of the most significant digit of the number being represented. For instance, for the value 34,281, the most significant digit (3) is in the ten thousands place, so the base unit represents 10,000. Effectively, 34,281 would be represented by approximately 3.4281 of these base unit lines.

Furthermore, considering both the human sense of number (**our limited ability to instantly grasp larger quantities**) and the properties of the decimal system (**where accumulating ten units of a certain place value effectively moves to the next higher place value**), I've established a rule: a maximum of ten horizontal lines are used in this visualization.

These lines are arranged into two groups, left and right, with each group containing a maximum of five lines. This structure likely aids perception by keeping the number of elements in each subgroup small, aligning with the principles of subitizing (the rapid recognition of small quantities).

When representing numbers that include a decimal fraction, the length of the final horizontal line is adjusted proportionally to represent the value after the decimal point. For example, if representing 3.4 base units, there would be three full lines and one final line whose length is 40% of a full line.
![image](https://github.com/user-attachments/assets/abba1231-6a5c-461f-b5ef-43d92a5969c7)
![image](https://github.com/user-attachments/assets/22bd288f-e950-41ed-afb5-6cdc7b64885b)
![image](https://github.com/user-attachments/assets/2e87fb27-0052-4c8c-8d6b-c782305f92a3)

[1] Dehaene, S. (2011). The number sense: How the mind creates mathematics (Rev. and updated ed.). Oxford University Press.