### PR TITLE
Update comparison visualization support for numeric data not full text

### DIFF
--- a/packages/gist-wsv/src/components/wordScaleVis/vBarChart.tsx
+++ b/packages/gist-wsv/src/components/wordScaleVis/vBarChart.tsx
@@ -6,6 +6,9 @@ import { Tooltip } from 'antd';
 
 const POSITIVE_INFINITY_PLACEHOLDER = 99999999;
 const NEGATIVE_INFINITY_PLACEHOLDER = -99999999;
+const HIGH_FIXED_VALUE = 10;
+const LOW_FIXED_VALUE = 5;
+const GROUP_PADDING = SVG_UNIT_WIDTH; // Special comparison group padding
 
 const VerticalBarChart: React.FC<ChartProps> = ({
   gistvisSpec,
@@ -14,179 +17,292 @@ const VerticalBarChart: React.FC<ChartProps> = ({
   setSelectedEntity,
 }: ChartProps) => {
   const [hoveredUniqueId, setHoveredUniqueId] = useState<string | null>(null);
-  useEffect(() => {
-    console.log('hoveredUniqueId:', hoveredUniqueId);
-    console.log('selectedEntity:', selectedEntity);
-  }, [selectedEntity]);
   const dataSpec = gistvisSpec.dataSpec ?? [];
+  const insightType = gistvisSpec.unitSegmentSpec?.insightType;
 
-  const verticalBarChartWidth = SVG_UNIT_WIDTH * dataSpec.length;
+  //Mode Determination
+  const isComparison = insightType === 'comparison';
+  const containsPositive = dataSpec.some((d) => d.value === POSITIVE_INFINITY_PLACEHOLDER);
+  const containsNegative = dataSpec.some((d) => d.value === NEGATIVE_INFINITY_PLACEHOLDER);
+  const isSpecialComparisonMode = isComparison && containsPositive && containsNegative;
 
-  const datasetMap: { [key in InsightType]?: number[] } = {
-    rank: dataSpec.map((d: DataSpec) => dataSpec.length + 1 - d.value),
-    comparison: dataSpec.map((d: DataSpec) => d.value),
-  };
+  //State for Layout and Data (depends on mode)
+  let finalWidth: number;
+  let knownCategories: JSX.Element[] = [];
+  let comparisonGroups: { [key: string]: DataSpec[] } = {}; // Only for special comparison
+  const groupLayouts: { group: DataSpec[]; startX: number; width: number }[] = []; // Only for special comparison
 
-  const baseDataset = datasetMap[gistvisSpec.unitSegmentSpec.insightType] ?? [];
-
-  const isSpecialComparisonCase =
-    gistvisSpec.unitSegmentSpec.insightType === 'comparison' &&
-    dataSpec.length === 2 &&
-    baseDataset.includes(POSITIVE_INFINITY_PLACEHOLDER) &&
-    baseDataset.includes(NEGATIVE_INFINITY_PLACEHOLDER);
-
-  let processedDataset: number[];
-  let yMax: number;
-
-  if (isSpecialComparisonCase) {
-    const HIGH_FIXED_VALUE = 10;
-    const LOW_FIXED_VALUE = 5;
-    processedDataset = baseDataset.map((val) =>
-      val === POSITIVE_INFINITY_PLACEHOLDER ? HIGH_FIXED_VALUE : LOW_FIXED_VALUE
+  //Special Comparison Mode Logic
+  if (isSpecialComparisonMode) {
+    comparisonGroups = dataSpec.reduce(
+      (acc, item) => {
+        const groupKey = item.space || item.feature || 'default_group';
+        if (!acc[groupKey]) {
+          acc[groupKey] = [];
+        }
+        acc[groupKey].push(item);
+        return acc;
+      },
+      {} as { [key: string]: DataSpec[] }
     );
-    yMax = HIGH_FIXED_VALUE;
+
+    const validComparisonGroups = Object.values(comparisonGroups).filter(
+      (group) =>
+        group.some((d) => d.value === POSITIVE_INFINITY_PLACEHOLDER) &&
+        group.some((d) => d.value === NEGATIVE_INFINITY_PLACEHOLDER)
+    );
+
+    let currentX = 0;
+    validComparisonGroups.forEach((group) => {
+      const groupWidth = group.length * SVG_UNIT_WIDTH;
+      groupLayouts.push({ group: group, startX: currentX, width: groupWidth });
+      currentX += groupWidth + GROUP_PADDING;
+    });
+    finalWidth = Math.max(0, currentX - GROUP_PADDING);
+
+    const yScaleSpecial = d3.scaleLinear().domain([0, HIGH_FIXED_VALUE]).range([SVG_HEIGHT, 0]);
+
+    knownCategories = groupLayouts.flatMap(({ group, startX }) => {
+      group.sort((a, b) => b.value - a.value); // Sort within group for consistent layout if desired
+
+      return group.map((d, itemIndexInGroup) => {
+        const uniqueId = `${d.space || ''}-${d.breakdown}-${d.feature}-${d.value}-${itemIndexInGroup}`; // Complex ID for special mode
+        const isHovered = uniqueId === hoveredUniqueId;
+        const hoverStyle = {
+          opacity: isHovered ? 1 : hoveredUniqueId === null && d.breakdown === selectedEntity ? 1 : 0.5,
+          transition: 'opacity 0.3s',
+        };
+        const valueForScale = d.value === POSITIVE_INFINITY_PLACEHOLDER ? HIGH_FIXED_VALUE : LOW_FIXED_VALUE;
+        const barY = yScaleSpecial(valueForScale);
+        const barHeight = SVG_HEIGHT - barY;
+        const barX = startX + itemIndexInGroup * SVG_UNIT_WIDTH;
+
+        return (
+          <rect
+            key={uniqueId}
+            x={barX}
+            y={barY >= 0 ? barY : 0}
+            width={SVG_UNIT_WIDTH}
+            height={barHeight >= 0 ? barHeight : 0}
+            fill={d.breakdown !== 'placeholder' ? colorScale(d.breakdown) : 'grey'}
+            style={hoverStyle}
+            onMouseOver={() => {
+              setSelectedEntity(d.breakdown);
+              setHoveredUniqueId(uniqueId);
+            }}
+            onMouseOut={() => {
+              setSelectedEntity('');
+              setHoveredUniqueId(null);
+            }}
+          />
+        );
+      });
+    });
+
+    // (Rank or Normal Comparison)
   } else {
-    processedDataset = baseDataset;
-    yMax = d3.max(processedDataset) ?? 1;
+    const datasetMap: { [key in InsightType]?: number[] } = {
+      rank: dataSpec.map((d: DataSpec) =>
+        d.value === NEGATIVE_INFINITY_PLACEHOLDER || d.value === POSITIVE_INFINITY_PLACEHOLDER
+          ? 0
+          : dataSpec.length + 1 - d.value
+      ), // Handle potential leftover placeholders in rank/normal data? Default to 0 height?
+      comparison: dataSpec.map((d: DataSpec) =>
+        d.value === NEGATIVE_INFINITY_PLACEHOLDER || d.value === POSITIVE_INFINITY_PLACEHOLDER ? 0 : d.value
+      ), // Handle potential leftover placeholders?
+    };
+    const dataset = insightType ? (datasetMap[insightType] ?? []) : [];
+
+    finalWidth = SVG_UNIT_WIDTH * dataSpec.length;
+    const xScale = d3.scaleLinear().domain([0, dataSpec.length]).range([0, finalWidth]);
+    const yMax = d3.max(dataset) ?? 1;
+    const yScale = d3.scaleLinear().domain([0, yMax]).range([SVG_HEIGHT, 0]);
+
+    knownCategories = dataSpec.map((d: DataSpec, i: number) => {
+      // Use simpler original ID format for these modes
+      const uniqueId = `${d.breakdown}-${d.feature}-${d.value}`;
+      const isHovered = uniqueId === hoveredUniqueId || (hoveredUniqueId === null && d.breakdown === selectedEntity);
+      const hoverStyle = {
+        opacity: isHovered ? 1 : 0.5,
+        transition: 'opacity 0.3s',
+      };
+      const valueForScale = dataset[i] ?? 0; // Use value from calculated dataset
+      const barY = yScale(valueForScale);
+      const barHeight = SVG_HEIGHT - barY;
+
+      return (
+        <rect
+          key={uniqueId}
+          x={xScale(i)}
+          y={barY >= 0 ? barY : 0} // Handle potential negative values if domain changes
+          width={SVG_UNIT_WIDTH}
+          height={barHeight >= 0 ? barHeight : 0} // Ensure non-negative height
+          fill={d.breakdown !== 'placeholder' ? colorScale(d.breakdown) : 'grey'}
+          style={hoverStyle}
+          onMouseOver={() => {
+            setSelectedEntity(d.breakdown);
+            setHoveredUniqueId(uniqueId);
+          }}
+          onMouseOut={() => {
+            setSelectedEntity('');
+            setHoveredUniqueId(null);
+          }}
+        />
+      );
+    });
   }
 
-  const xScale = d3.scaleLinear().domain([0, processedDataset.length]).range([0, verticalBarChartWidth]);
-  const yScale = d3.scaleLinear().domain([0, yMax]).range([SVG_HEIGHT, 0]);
-
-  const knownCategories = dataSpec.map((d: DataSpec, i: number) => {
-    const uniqueId = `${d.breakdown}-${d.feature}-${d.value}`;
-    const isHovered = uniqueId === hoveredUniqueId || (hoveredUniqueId === null && d.breakdown === selectedEntity);
-    const hoverStyle = {
-      opacity: isHovered ? 1 : 0.5,
-      transition: 'opacity 0.3s',
-    };
-    const valueForScale = processedDataset[i];
-    const barY = yScale(valueForScale);
-    const barHeight = SVG_HEIGHT - barY;
-
-    return (
-      <rect
-        key={uniqueId}
-        x={xScale(i)}
-        y={barY >= 0 ? barY : 0}
-        width={SVG_UNIT_WIDTH}
-        height={barHeight >= 0 ? barHeight : 0}
-        fill={d.breakdown !== 'placeholder' ? colorScale(d.breakdown) : 'grey'}
-        style={hoverStyle}
-        onMouseOver={() => {
-          setSelectedEntity(d.breakdown);
-          setHoveredUniqueId(uniqueId);
-        }}
-        onMouseOut={() => {
-          setSelectedEntity('');
-          setHoveredUniqueId(null);
-        }}
-      />
-    );
-  });
+  //Tooltip Logic (Handles all modes)
+  const formatBreakdownList = (items: DataSpec[]) => {
+    return items.map((item, index) => (
+      <React.Fragment key={item.breakdown + index}>
+        <span style={{ color: colorScale(item.breakdown) }}>
+          {/* Display breakdown and optionally feature for context */}
+          {item.breakdown} {/* ({item.feature}) - uncomment if feature needed */}
+        </span>
+        {index < items.length - 2 ? ', ' : index === items.length - 2 ? ' and ' : ''}
+      </React.Fragment>
+    ));
+  };
 
   const getToolTipContent = () => {
     if (hoveredUniqueId === null) {
       return null;
     }
 
-    if (selectedEntity === 'placeholder') {
-      return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
-    }
-
-    if (gistvisSpec.unitSegmentSpec.insightType === 'comparison') {
-      const currentCase = dataSpec.find((d) => `${d.breakdown}-${d.feature}-${d.value}` === hoveredUniqueId);
-      if (!currentCase) {
-        return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Comparison</div>;
-      }
-
-      const isSpecialTooltipCase =
-        dataSpec.length === 2 &&
-        ((dataSpec[0].value === POSITIVE_INFINITY_PLACEHOLDER && dataSpec[1].value === NEGATIVE_INFINITY_PLACEHOLDER) ||
-          (dataSpec[0].value === NEGATIVE_INFINITY_PLACEHOLDER && dataSpec[1].value === POSITIVE_INFINITY_PLACEHOLDER));
-
-      if (isSpecialTooltipCase) {
-        const highCase = dataSpec.find((d) => d.value === POSITIVE_INFINITY_PLACEHOLDER);
-        const lowCase = dataSpec.find((d) => d.value === NEGATIVE_INFINITY_PLACEHOLDER);
-
-        if (highCase && lowCase && currentCase) {
-          if (currentCase.value === POSITIVE_INFINITY_PLACEHOLDER) {
-            return (
-              <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
-                <span style={{ color: colorScale(highCase.breakdown) }}>{highCase.breakdown}</span> is higher than{' '}
-                <span style={{ color: colorScale(lowCase.breakdown) }}>{lowCase.breakdown}</span>.
-              </div>
-            );
-          } else if (currentCase.value === NEGATIVE_INFINITY_PLACEHOLDER) {
-            return (
-              <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
-                <span style={{ color: colorScale(lowCase.breakdown) }}>{lowCase.breakdown}</span> is lower than{' '}
-                <span style={{ color: colorScale(highCase.breakdown) }}>{highCase.breakdown}</span>.
-              </div>
-            );
+    let currentCase: DataSpec | undefined;
+    let currentGroup: DataSpec[] | undefined; // For special comparison context
+    // Find the hovered data item based on the ID structure
+    if (isSpecialComparisonMode) {
+      for (const layout of groupLayouts) {
+        for (let i = 0; i < layout.group.length; i++) {
+          const d = layout.group[i];
+          const idToCheck = `${d.space || ''}-${d.breakdown}-${d.feature}-${d.value}-${i}`;
+          if (idToCheck === hoveredUniqueId) {
+            currentCase = d;
+            currentGroup = layout.group;
+            break;
           }
         }
-        // Fallback if cases not found correctly
+        if (currentCase) break;
+      }
+    } else {
+      // Find based on original ID format
+      currentCase = dataSpec.find((d) => `${d.breakdown}-${d.feature}-${d.value}` === hoveredUniqueId);
+    }
+
+    if (!currentCase) {
+      return null; // Should not happen if hoveredUniqueId is valid
+    }
+
+    if (currentCase.breakdown === 'placeholder') {
+      return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Placeholder</div>; // Adjusted text
+    }
+
+    // Special Comparison Tooltip
+    if (
+      isSpecialComparisonMode &&
+      currentGroup &&
+      (currentCase.value === POSITIVE_INFINITY_PLACEHOLDER || currentCase.value === NEGATIVE_INFINITY_PLACEHOLDER)
+    ) {
+      const peers = currentGroup.filter((d) => d !== currentCase);
+      const highPeers = peers.filter((d) => d.value === POSITIVE_INFINITY_PLACEHOLDER);
+      const lowPeers = peers.filter((d) => d.value === NEGATIVE_INFINITY_PLACEHOLDER);
+      let comparisonText = '';
+      let comparisonList: DataSpec[] = [];
+
+      if (currentCase.value === POSITIVE_INFINITY_PLACEHOLDER) {
+        comparisonText = 'is higher than';
+        comparisonList = lowPeers;
+      } else {
+        comparisonText = 'is lower than';
+        comparisonList = highPeers;
+      }
+
+      if (comparisonList.length > 0) {
         return (
-          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>
-            Comparison info unavailable
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            <span style={{ color: colorScale(currentCase.breakdown) }}>{currentCase.breakdown}</span> (
+            {currentCase.feature || currentCase.space}) {comparisonText} {formatBreakdownList(comparisonList)}.
           </div>
         );
       } else {
-        const refCase = dataSpec.find((d) => d !== currentCase) || dataSpec[0];
-        if (typeof currentCase.value !== 'number' || typeof refCase.value !== 'number') {
-          return (
-            <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>
-              Comparison data invalid
-            </div>
-          );
-        }
-        const diff = Math.abs(currentCase.value - refCase.value);
-        if (refCase.breakdown === selectedEntity) {
-          return (
-            <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
-              The difference between{' '}
-              <span style={{ color: colorScale(refCase.breakdown) }}>
-                {refCase.breakdown} ({refCase.value})
-              </span>{' '}
-              and {currentCase.breakdown} ({currentCase.value}) is {diff}.
-            </div>
-          );
-        } else {
-          return (
-            <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
-              The difference between{' '}
-              <span style={{ color: colorScale(refCase.breakdown) }}>
-                {refCase.breakdown} ({refCase.value})
-              </span>{' '}
-              and{' '}
-              <span style={{ color: colorScale(selectedEntity) }}>
-                {selectedEntity} ({currentCase.value})
-              </span>{' '}
-              is {diff}.
-            </div>
-          );
-        }
+        return (
+          // Fallback if no peers to compare with
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            <span style={{ color: colorScale(currentCase.breakdown) }}>{currentCase.breakdown}</span> (
+            {currentCase.feature || currentCase.space}).
+          </div>
+        );
       }
-    } else if (gistvisSpec.unitSegmentSpec.insightType === 'rank') {
-      const rankData = dataSpec.find((d) => `${d.breakdown}-${d.feature}-${d.value}` === hoveredUniqueId);
-      const rank = rankData?.value;
-      if (!rankData || rank === undefined) {
-        return <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>Rank</div>;
+      // Normal Comparison Tooltip
+    } else if (insightType === 'comparison' && !isSpecialComparisonMode) {
+      const refCase = dataSpec.find((d) => d !== currentCase && d.breakdown !== 'placeholder'); // Find a non-placeholder reference
+      if (!refCase) {
+        // Handle case with only one non-placeholder item
+        return (
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+            {currentCase.breakdown}: {currentCase.value}
+          </div>
+        );
+      }
+      // Ensure values are numbers before calculating diff
+      if (typeof currentCase.value !== 'number' || typeof refCase.value !== 'number') {
+        return (
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>
+            Comparison data invalid
+          </div>
+        );
+      }
+      const diff = Math.abs(currentCase.value - refCase.value);
+      const currentDisplayValue = currentCase.value;
+      const refDisplayValue = refCase.value;
+      return (
+        <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'black', fontWeight: 'bold' }}>
+          Comparing{' '}
+          <span style={{ color: colorScale(currentCase.breakdown) }}>
+            {currentCase.breakdown} ({currentDisplayValue})
+          </span>{' '}
+          and{' '}
+          <span style={{ color: colorScale(refCase.breakdown) }}>
+            {refCase.breakdown} ({refDisplayValue})
+          </span>
+          . Difference is {diff}.
+        </div>
+      );
+
+      // Rank Tooltip
+    } else if (insightType === 'rank') {
+      const rankData = currentCase;
+      const rankValue = rankData.value;
+
+      if (
+        rankValue === undefined ||
+        typeof rankValue !== 'number' ||
+        rankValue === POSITIVE_INFINITY_PLACEHOLDER ||
+        rankValue === NEGATIVE_INFINITY_PLACEHOLDER
+      ) {
+        // Add check for special values in rank data
+        return (
+          <div style={{ lineHeight: 1.1, fontSize: '14px', color: 'grey', fontWeight: 'bold' }}>
+            Rank data unavailable
+          </div>
+        );
       }
       return (
-        <div style={{ lineHeight: 1.1, fontSize: '14px', color: colorScale(selectedEntity), fontWeight: 'bold' }}>
-          {rankData.feature + ' ' + rank + ': ' + selectedEntity}
+        <div style={{ lineHeight: 1.1, fontSize: '14px', color: colorScale(rankData.breakdown), fontWeight: 'bold' }}>
+          {rankData.feature} Rank {rankValue}: {rankData.breakdown}
         </div>
       );
     }
-    return null;
+
+    return null; // Fallback for unhandled cases
   };
 
   const visElement = (
-    <Tooltip title={getToolTipContent()} placement="bottom" color="#ffffff">
-      <svg height={SVG_HEIGHT} width={verticalBarChartWidth}>
-        {knownCategories && [...knownCategories]}
+    <Tooltip title={getToolTipContent()} placement="bottom" color="#ffffff" mouseEnterDelay={0.1}>
+      <svg height={SVG_HEIGHT} width={finalWidth}>
+        {knownCategories}
       </svg>
     </Tooltip>
   );

--- a/packages/gist-wsv/src/utils/postProcess.ts
+++ b/packages/gist-wsv/src/utils/postProcess.ts
@@ -30,14 +30,14 @@ export const getHighlightPos = (gistVisSpec: GistvisSpec, type: 'phrase' | 'enti
 };
 
 export const getUniqueEntities = (entityPos: EntitySpec[]) => {
-  return uniqBy(entityPos, 'entity').map(d => d.entity);
+  return uniqBy(entityPos, 'entity').map((d) => d.entity);
 };
 
 export const getNonOverlappingEntities = (entityPos: EntitySpec[]) => {
   // Filter out zero-length entities and sort by start position
-  const validEntities = entityPos.filter(entity => entity.postion.end > entity.postion.start);
+  const validEntities = entityPos.filter((entity) => entity.postion.end > entity.postion.start);
   const sortedEntityPos = sortBy(validEntities, ['postion.start']);
-  
+
   // Filter out overlapping entities using reduce
   const nonOverlappingEntities = sortedEntityPos.reduce((acc: EntitySpec[], entity: EntitySpec) => {
     if (acc.length === 0 || entity.postion.start >= acc[acc.length - 1].postion.end) {
@@ -98,6 +98,11 @@ export const getProductionVisSpec = (text: string, entityPos: EntitySpec[], disp
     contentArray.push({
       displayType: 'text',
       content: text.slice(endPos) + ' ',
+    });
+  } else if (lastEnd === text.length) {
+    contentArray.push({
+      displayType: 'word-scale-vis',
+      content: ' ',
     });
   }
   return contentArray;

--- a/site/src/modules/llm/extractor/extractComparison.ts
+++ b/site/src/modules/llm/extractor/extractComparison.ts
@@ -17,7 +17,10 @@ const extrComp = async (model: ChatOpenAI<ChatOpenAICallOptions>, textContent: G
         ${ExtractorSystemInstruction}
         
         This sentence contains comparison. Comparison refers to the act of comparing two or more data attributes or comparing the target object with previous values, especially along a time series. 
-        First, you should extract the object of comparison, usually an entity. Then convert the data into numbers. The value you extract should be the value of the comparison object and not the difference, if the context only contains information about the difference, e.g. a difference of 30, then please fill the base entity with value 0 and the comparison entity the difference value (in this case 30) based on the information.
+        First, you should extract the objects of comparison, usually entities. Then, determine how to populate the data values based on the information provided in the sentence, following these prioritized steps:
+        1.  Direct Numerical Values: If specific numerical values are present for the comparison objects, extract these exact values. Ensure the value extracted is the object's actual value, not a difference.
+        2.  Difference Only: If the context only provides the difference between the objects (e.g., 'a difference of 30', 'A is 30 higher than B'), assign the base entity a value of 0 and the comparison entity the value representing the difference (e.g., 30), based on the information.
+        3.  Missing or Incomplete Numerical Data: If specific numerical values are absent or insufficient for direct comparison (e.g., 'A performed better than B' without numbers), analyze the sentence's semantics to understand the relative relationship. In this scenario, instead of numerical values, populate the relevant fields in the output structure by indicating which entity is relatively 'higher' and which is 'lower', strictly following the specified format instructions.
         Specifically, for 'category_key', identify the subject of comparison with its context, e.g., "the category of GDP growth" instead of just "entity". But the 'value_key' of all data items should keep the same.
         For 'value_key', specify the exact context of the value being compared, e.g., "the GDP growth rate" instead of just "value". But the 'category_key' of all data items should keep the same.
         The user intends to use a bar chart to represent the comparison. Please find the most suitable location for placing the bar chart and output the previous word in the recommended location.
@@ -34,7 +37,24 @@ const extrComp = async (model: ChatOpenAI<ChatOpenAICallOptions>, textContent: G
     paragraph: 'User:' + textContent.text,
   });
   // console.log(response);
-
+  console.log(
+    'prompt:',
+    `
+        ${SystemInstruction}
+        ${ExtractorSystemInstruction}
+        
+        This sentence contains comparison. Comparison refers to the act of comparing two or more data attributes or comparing the target object with previous values, especially along a time series. 
+        First, you should extract the objects of comparison, usually entities. Then, determine how to populate the data values based on the information provided in the sentence, following these prioritized steps:
+        1.  Direct Numerical Values: If specific numerical values are present for the comparison objects, extract these exact values. Ensure the value extracted is the object's actual value, not a difference.
+        2.  Difference Only: If the context only provides the difference between the objects (e.g., 'a difference of 30', 'A is 30 higher than B'), assign the base entity a value of 0 and the comparison entity the value representing the difference (e.g., 30), based on the information.
+        3.  Missing or Incomplete Numerical Data: If specific numerical values are absent or insufficient for direct comparison (e.g., 'A performed better than B' without numbers), analyze the sentence's semantics to understand the relative relationship. In this scenario, instead of numerical values, populate the relevant fields in the output structure by indicating which entity is relatively 'higher' and which is 'lower', strictly following the specified format instructions.
+        Specifically, for 'category_key', identify the subject of comparison with its context, e.g., "the category of GDP growth" instead of just "entity". But the 'value_key' of all data items should keep the same.
+        For 'value_key', specify the exact context of the value being compared, e.g., "the GDP growth rate" instead of just "value". But the 'category_key' of all data items should keep the same.
+        The user intends to use a bar chart to represent the comparison. Please find the most suitable location for placing the bar chart and output the previous word in the recommended location.
+        \n${parser.getFormatInstructions()}\n${'insightType:' + textContent.type}\n${'User:' + textContent.text}
+        `
+  );
+  console.log('response:', response);
   return response as ExtractorType;
 
   // // const newResponse = TransformData(response);

--- a/site/src/modules/llm/extractor/extractComparison.ts
+++ b/site/src/modules/llm/extractor/extractComparison.ts
@@ -37,24 +37,6 @@ const extrComp = async (model: ChatOpenAI<ChatOpenAICallOptions>, textContent: G
     paragraph: 'User:' + textContent.text,
   });
   // console.log(response);
-  console.log(
-    'prompt:',
-    `
-        ${SystemInstruction}
-        ${ExtractorSystemInstruction}
-        
-        This sentence contains comparison. Comparison refers to the act of comparing two or more data attributes or comparing the target object with previous values, especially along a time series. 
-        First, you should extract the objects of comparison, usually entities. Then, determine how to populate the data values based on the information provided in the sentence, following these prioritized steps:
-        1.  Direct Numerical Values: If specific numerical values are present for the comparison objects, extract these exact values. Ensure the value extracted is the object's actual value, not a difference.
-        2.  Difference Only: If the context only provides the difference between the objects (e.g., 'a difference of 30', 'A is 30 higher than B'), assign the base entity a value of 0 and the comparison entity the value representing the difference (e.g., 30), based on the information.
-        3.  Missing or Incomplete Numerical Data: If specific numerical values are absent or insufficient for direct comparison (e.g., 'A performed better than B' without numbers), analyze the sentence's semantics to understand the relative relationship. In this scenario, instead of numerical values, populate the relevant fields in the output structure by indicating which entity is relatively 'higher' and which is 'lower', strictly following the specified format instructions.
-        Specifically, for 'category_key', identify the subject of comparison with its context, e.g., "the category of GDP growth" instead of just "entity". But the 'value_key' of all data items should keep the same.
-        For 'value_key', specify the exact context of the value being compared, e.g., "the GDP growth rate" instead of just "value". But the 'category_key' of all data items should keep the same.
-        The user intends to use a bar chart to represent the comparison. Please find the most suitable location for placing the bar chart and output the previous word in the recommended location.
-        \n${parser.getFormatInstructions()}\n${'insightType:' + textContent.type}\n${'User:' + textContent.text}
-        `
-  );
-  console.log('response:', response);
   return response as ExtractorType;
 
   // // const newResponse = TransformData(response);

--- a/site/src/modules/llm/extractor/utils.ts
+++ b/site/src/modules/llm/extractor/utils.ts
@@ -12,7 +12,7 @@ export const SpecDescriptions = {
     'The definition of the value of the data item according to the context. If it does not exist or is uncertain, return an empty string',
   VALUE_VALUE_DESCRIPTION: {
     comparison:
-      'The value (only numbers) of the value of the data item. If it does not exist or is uncertain, return NAN',
+      "The value (only numbers or string of 'higher' and 'lower') of the value of the data item. If it does not exist or is uncertain, return NAN",
     extreme: 'The extreme (already converted into numbers).  If it does not exist or is uncertain, return NAN',
     proportion:
       'The value of proportion (already converted into decimals). If it does not exist or is uncertain, return NAN',
@@ -51,6 +51,10 @@ export const getZodFormatting = (insightType: InsightType) => {
           .transform((value) => {
             if (typeof value === 'string' && value.toUpperCase() === 'NAN') {
               return NaN;
+            } else if (typeof value === 'string' && value.toUpperCase() === 'HIGHER') {
+              return 99999999;
+            } else if (typeof value === 'string' && value.toUpperCase() === 'LOWER') {
+              return -99999999;
             } else {
               return parseValue(value);
             }


### PR DESCRIPTION
I changed `Extractor`'s prompt word for `comparison`, and the LLM is now able to output `99999999` and `-9999999999` to indicate the size relationship between entities when no numbers are fetched, allowing for `comparison` text to be visualized without numbers.
![image](https://github.com/user-attachments/assets/82df32f6-834f-45fe-b605-b062a7886cb6)

> The dataspec of the second sentence is correct. Some other bugs are causing the disappearance of the visualization, which I will handle.